### PR TITLE
Very basic logic around Multi-line PowerShell.

### DIFF
--- a/ConvertToPowerShellNoteBook.ps1
+++ b/ConvertToPowerShellNoteBook.ps1
@@ -11,8 +11,8 @@ function ConvertTo-PowerShellNoteBook {
     Parsing section.
     #################################################################################################>
     
-    try{$CommentRanges = [System.Management.Automation.PSParser]::Tokenize((Get-Content $InputFileName), [ref]$null).Where({$_.Type -eq 'Comment'})
-    | SELECT -Property Start, Length, Type, Content }
+    try{$CommentRanges = [System.Management.Automation.PSParser]::Tokenize((Get-Content $InputFileName), [ref]$null).Where({$_.Type -eq 'Comment'}) |
+    Select-Object -Property Start, Length, Type, Content }
     Catch{"This is not a valid PowerShell file"}
     
     $s = Get-Content -Raw ( Resolve-Path $InputFileName )
@@ -67,7 +67,7 @@ function ConvertTo-PowerShellNoteBook {
     
     New-PSNotebook -NoteBookName $OutputNotebookName {
     
-        foreach($Block in $AllBlocks | SORT Start ) {
+        foreach($Block in $AllBlocks | Sort-Object Start ) {
     
             
             switch ($Block.Type) {

--- a/ConvertToPowerShellNoteBook.ps1
+++ b/ConvertToPowerShellNoteBook.ps1
@@ -7,16 +7,84 @@ function ConvertTo-PowerShellNoteBook {
         $InputFileName,
         $OutputNotebookName
     )
-
+    <#################################################################################################
+    Parsing section.
+    #################################################################################################>
+    
+    try{$CommentRanges = [System.Management.Automation.PSParser]::Tokenize((Get-Content $InputFileName), [ref]$null).Where({$_.Type -eq 'Comment'})
+    | SELECT -Property Start, Length, Type, Content }
+    Catch{"This is not a valid PowerShell file"}
+    
+    $s = Get-Content -Raw ( Resolve-Path $InputFileName )
+    
+    $BlocksWitGaps = @()
+    $Previous = $null
+    foreach($CommentBlock in $CommentRanges ) {
+        $BlockOffsets=[ordered]@{
+        Start = $CommentBlock.Start;
+        StopOffset = $CommentBlock.Start+$CommentBlock.Length;
+        Length = $CommentBlock.Length;
+        GapLength = [int] $CommentBlock.Start-$Previous.StopOffset;
+        PreviousStart = $Previous.Start;
+        PreviousStopOffset = $Previous.StopOffset;
+        Type = 'Code';
+        GapText = IF($CommentBlock.Start-$Previous.StopOffset -gt 1){[string] $s.Substring($Previous.StopOffset, ($CommentBlock.Start-$Previous.StopOffset)).trimstart()}else {[string] ''};
+        Content = $CommentBlock.Content
+        }
+    
+        $Previous=$BlockOffsets
+        $BlocksWitGaps+=[pscustomobject] $BlockOffsets
+    }
+    
+    
+    $AllBlocks = @()
+    $Previous = $null
+    $AllBlocks = $CommentRanges
+    <# Catch anything missed from the tail of the file, add it to $AllBlocks #>
+    if(($CommentBlock.Start+$CommentBlock.Length) -lt $s.Length){$AllBlocks+=[pscustomobject][ordered]@{
+        Start = ($CommentBlock.Start+$CommentBlock.Length);
+        Length = $s.Length-($CommentBlock.Start+$CommentBlock.Length);
+        Type = 'Gap';
+        Content = $s.Substring(($CommentBlock.Start+$CommentBlock.Length), ($s.Length-($CommentBlock.Start+$CommentBlock.Length))).trimstart()}
+    }
+    
+    foreach($GapBlock in $BlocksWitGaps ) {
+        $GapOffsets=[ordered]@{
+        Start = $GapBlock.PreviousStopOffset;
+        StopOffset = $GapBlock.Start;
+        Length = $GapBlock.GapLength;
+        Type = 'Gap';
+        Content = $GapBlock.GapText.trimstart()
+        }
+    
+        $Previous=$GapOffsets
+        $AllBlocks+=if($GapOffsets.Length -gt 0){[pscustomobject] $GapOffsets}
+    }
+    
+    <#################################################################################################
+    Notebook creation section.
+    #################################################################################################>    
+    
     New-PSNotebook -NoteBookName $OutputNotebookName {
-        switch -file ($InputFileName) {
-            { $_.Trim().Length -eq 0 } { continue }
-            { $_.startswith('#') } {
-                Add-NotebookMarkdown $_
+    
+        foreach($Block in $AllBlocks | SORT Start ) {
+    
+            
+            switch ($Block.Type) {
+                'Comment' {$TextBlock = $s.Substring($Block.Start, $Block.Length) -replace ("\n", "   `n  ")
+    
+                            if($TextBlock.Trim().length -gt 0){
+                                Add-NotebookMarkdown -markdown (-join $TextBlock)
+                            }
+                        }
+                'Gap'   {$GapBlock = $s.Substring($Block.Start, $Block.Length)
+    
+                            if($GapBlock.Trim().length -gt 0){
+                                Add-NotebookCode -code (-join $GapBlock.trimstart().trimend()) -replace ("\n", "   `n  ")
+                            }
+                        }
             }
-            default {
-                Add-NotebookCode $_
-            }
+    
         }
     }
 }

--- a/__tests__/ConvertToPowerShellNotebook.tests.ps1
+++ b/__tests__/ConvertToPowerShellNotebook.tests.ps1
@@ -27,4 +27,29 @@ Describe "Test ConvertTo-PowerShellNoteBook" {
         $actual[2].Source | Should BeExactly '# Create a function'
         $actual[3].Source | Should BeExactly '# Use the function'
     }
+
+    It "Should convert the file to an ipynb" {
+        $demoTextFile = "$PSScriptRoot\DemoFiles\GetParsedSqlOffsets.ps1"
+        $fullName = "TestDrive:\GetParsedSqlOffsets.ipnyb"
+
+        ConvertTo-PowerShellNoteBook -InputFileName $demoTextFile -OutputNotebookName $fullName
+        { Test-Path $fullName } | Should Be $true
+
+        $actual = Get-NotebookContent -NoteBookFullName $fullName
+        $actual.Count | Should Be 13
+
+        $actual = Get-NotebookContent -NoteBookFullName $fullName -JustCode
+
+        $actual.Count | Should Be 7
+        $actual[0].Source | Should BeExactly 'function Get-ParsedSqlOffsets{
+    [CmdletBinding()]
+    param(
+        $ScriptPath
+    )'
+
+        $actual = Get-NotebookContent -NoteBookFullName $fullName -JustMarkdown
+
+        $actual.Count | Should Be 6
+        $actual[2].Source  | Should BeExactly '<#################################################################################################>'
+    }
 }

--- a/__tests__/DemoFiles/GetParsedSqlOffsets.ps1
+++ b/__tests__/DemoFiles/GetParsedSqlOffsets.ps1
@@ -1,0 +1,81 @@
+function Get-ParsedSqlOffsets{
+    [CmdletBinding()]
+    param(
+        $ScriptPath
+    )
+<#################################################################################################
+Pre-reqs: Install the SqlServer module.
+#################################################################################################>
+Import-Module SqlServer
+$ScriptDom = Join-Path -Path (Get-Module -Name SqlServer).ModuleBase -ChildPath 'Microsoft.SqlServer.TransactSql.ScriptDom.dll'
+if((Test-Path $ScriptDom) -eq $true ) {Add-Type -LiteralPath $ScriptDom}
+<#################################################################################################
+Qucik Helper-function to turn the file into a script fragment, using scriptdom.
+#################################################################################################>
+function Get-ParsedSql($ScriptPath){
+    [Microsoft.SqlServer.TransactSql.ScriptDom.TSql150Parser] $parser = new-object Microsoft.SqlServer.TransactSql.ScriptDom.TSql150Parser($false)
+    $Reader = New-Object -TypeName System.IO.StreamReader -ArgumentList $ScriptToParse
+    $Errors = $null
+    $ScriptFrag = $parser.Parse($Reader, [ref]$Errors)
+    return $ScriptFrag
+    }
+    <#################################################################################################>
+function Get-ScriptFragment($ScriptPath){
+[Microsoft.SqlServer.TransactSql.ScriptDom.TSql150Parser] $parser = new-object Microsoft.SqlServer.TransactSql.ScriptDom.TSql150Parser($false)
+$Reader = New-Object -TypeName System.IO.StreamReader -ArgumentList $ScriptPath
+$Errors = $null
+$ScriptFrag = $parser.Parse($Reader, [ref]$Errors)
+# Look for MultilineComment within Statements
+($ScriptFrag.ScriptTokenStream).where({$_.TokenType -eq 'MultilineComment'})
+}
+<#################################################################################################
+Checking for Batch length
+#################################################################################################>
+$s = Get-Content -Raw ( Resolve-Path $ScriptToParse )
+$ParsedSql = Get-ParsedSql $ScriptToParse
+$SqlBatches = @()
+$SqlBatch = @()
+$id=1
+foreach($Batch in $ParsedSql.Batches) {
+    $SqlBatch=[pscustomobject][Ordered]@{
+    StartOffset = $Batch.StartOffset;
+    StopOffset  = $Batch.StartOffset+$Batch.FragmentLength;
+    Length      = $Batch.FragmentLength;
+    StartColumn = $Batch.StartColumn;
+    BatchId     = $id;
+    BlockType   = 'Code';
+    Text        = $s.Substring($Batch.StartOffset, $Batch.FragmentLength)
+    }
+    $SqlBatches+=$SqlBatch
+    $id++
+}
+
+$ScriptFrags = Get-ScriptFragment -ScriptPath $ScriptToParse
+$Comments = @()
+$Comment = @()
+foreach($Frag in $ScriptFrags ) {
+    $Comment=[pscustomobject][Ordered]@{
+    StartOffset = $Frag.Offset;
+    StopOffset = $Frag.Offset+$Frag.Text.Length;
+    Length = $Frag.Text.Length;
+    StartColumn = $Frag.Column;
+    CommentLocation = $null;
+    BlockType = 'Comment';
+    Text = $Frag.Text
+    }
+
+    foreach($SqlBatch in $SqlBatches){
+
+    if($Comment.StartOffset -ge $SqlBatch.StartOffset -and $Comment.StartOffset -le $SqlBatch.StopOffset)
+    {$Comment.CommentLocation = "Within SQL Batch $($SqlBatch.BatchId)"}
+    else {if($Comment.CommentLocation -notlike '*Within*'){$Comment.CommentLocation = "Outside"}}
+    }
+    $Comments+=$Comment
+}
+
+<#################################################################################################
+This is the basic product.
+#################################################################################################>
+$NotebookBlocks = $SqlBatches + ($Comments | WHERE { $_.CommentLocation -eq 'Outside' })
+$NotebookBlocks | SORT StartOffset
+}

--- a/__tests__/DemoFiles/ParsingExamples.ps1
+++ b/__tests__/DemoFiles/ParsingExamples.ps1
@@ -1,0 +1,11 @@
+# # This is file is an example of what _should_ happen when converting a .PS1 file to a .IPYNB file.
+ps | select -first 10
+
+# Get first 10 services
+gsv | select -first 10
+
+# Create a function
+function SayHello($p) {"Hello $p"}
+
+# Use the function
+SayHello World

--- a/__tests__/GetNotebook.tests.ps1
+++ b/__tests__/GetNotebook.tests.ps1
@@ -24,7 +24,7 @@ Describe "Test PS Notebooks" {
 
     It "Should find notebooks in specified directory" {
         $actual = @(Get-Notebook "$PSScriptRoot\GoodNotebooks")
-        $actual.Count | Should Be 5
+        $actual.Count | Should Be 6
     }
 
     It "Should find a notebook by name in specified directory" {

--- a/__tests__/GoodConvertedNotebooks/GetParsedSqlOffsets.ipynb
+++ b/__tests__/GoodConvertedNotebooks/GetParsedSqlOffsets.ipynb
@@ -1,0 +1,124 @@
+﻿{
+    "metadata": {
+        "kernelspec": {
+            "name": "powershell",
+            "display_name": "PowerShell"
+        },
+        "language_info": {
+            "name": "powershell",
+            "codemirror_mode": "shell",
+            "mimetype": "text/x-sh",
+            "file_extension": ".ps1"
+        }
+    },
+    "nbformat_minor": 2,
+    "nbformat": 4,
+    "cells": [
+        {
+    "cell_type":  "code",
+    "source":  [
+                   "function Get-ParsedSqlOffsets{\r\n    [CmdletBinding()]\r\n    param(\r\n        $ScriptPath\r\n    )"
+               ],
+    "metadata":  {
+                     "azdata_cell_guid":  "24d07b61-2359-4c81-8766-607fe4da68f5"
+                 },
+    "outputs":  [
+                    {
+                        "name":  "stdout",
+                        "output_type":  "stream",
+                        "text":  ""
+                    }
+                ]
+},{"cell_type":"markdown","metadata":{},"source":["\u003c#################################################################################################\r   \n  Pre-reqs: Install the SqlServer module.\r   \n  #################################################################################################\u003e"]},{
+    "cell_type":  "code",
+    "source":  [
+                   "Import-Module SqlServer\r\n$ScriptDom = Join-Path -Path (Get-Module -Name SqlServer).ModuleBase -ChildPath \u0027Microsoft.SqlServer.TransactSql.ScriptDom.dll\u0027\r\nif((Test-Path $ScriptDom) -eq $true ) {Add-Type -LiteralPath $ScriptDom}"
+               ],
+    "metadata":  {
+                     "azdata_cell_guid":  "ff00ad39-ce3d-452a-900f-0dd16b9571a7"
+                 },
+    "outputs":  [
+                    {
+                        "name":  "stdout",
+                        "output_type":  "stream",
+                        "text":  ""
+                    }
+                ]
+},{"cell_type":"markdown","metadata":{},"source":["\u003c#################################################################################################\r   \n  Qucik Helper-function to turn the file into a script fragment, using scriptdom.\r   \n  #################################################################################################\u003e"]},{
+    "cell_type":  "code",
+    "source":  [
+                   "function Get-ParsedSql($ScriptPath){\r\n    [Microsoft.SqlServer.TransactSql.ScriptDom.TSql150Parser] $parser = new-object Microsoft.SqlServer.TransactSql.ScriptDom.TSql150Parser($false)\r\n    $Reader = New-Object -TypeName System.IO.StreamReader -ArgumentList $ScriptToParse\r\n    $Errors = $null\r\n    $ScriptFrag = $parser.Parse($Reader, [ref]$Errors)\r\n    return $ScriptFrag\r\n    }"
+               ],
+    "metadata":  {
+                     "azdata_cell_guid":  "b05d1f90-709d-44fa-8b92-a2217daf07d2"
+                 },
+    "outputs":  [
+                    {
+                        "name":  "stdout",
+                        "output_type":  "stream",
+                        "text":  ""
+                    }
+                ]
+},{"cell_type":"markdown","metadata":{},"source":["\u003c#################################################################################################\u003e"]},{
+    "cell_type":  "code",
+    "source":  [
+                   "function Get-ScriptFragment($ScriptPath){\r\n[Microsoft.SqlServer.TransactSql.ScriptDom.TSql150Parser] $parser = new-object Microsoft.SqlServer.TransactSql.ScriptDom.TSql150Parser($false)\r\n$Reader = New-Object -TypeName System.IO.StreamReader -ArgumentList $ScriptPath\r\n$Errors = $null\r\n$ScriptFrag = $parser.Parse($Reader, [ref]$Errors)"
+               ],
+    "metadata":  {
+                     "azdata_cell_guid":  "9ed4793a-a4e1-4516-adca-c34306e3f8f7"
+                 },
+    "outputs":  [
+                    {
+                        "name":  "stdout",
+                        "output_type":  "stream",
+                        "text":  ""
+                    }
+                ]
+},{"cell_type":"markdown","metadata":{},"source":["# Look for MultilineComment within Statements"]},{
+    "cell_type":  "code",
+    "source":  [
+                   "($ScriptFrag.ScriptTokenStream).where({$_.TokenType -eq \u0027MultilineComment\u0027})\r\n}"
+               ],
+    "metadata":  {
+                     "azdata_cell_guid":  "ea53a7ff-3b77-4a01-8f74-31a46e5fde25"
+                 },
+    "outputs":  [
+                    {
+                        "name":  "stdout",
+                        "output_type":  "stream",
+                        "text":  ""
+                    }
+                ]
+},{"cell_type":"markdown","metadata":{},"source":["\u003c#################################################################################################\r   \n  Checking for Batch length\r   \n  #################################################################################################\u003e"]},{
+    "cell_type":  "code",
+    "source":  [
+                   "$s = Get-Content -Raw ( Resolve-Path $ScriptToParse )\r\n$ParsedSql = Get-ParsedSql $ScriptToParse\r\n$SqlBatches = @()\r\n$SqlBatch = @()\r\n$id=1\r\nforeach($Batch in $ParsedSql.Batches) {\r\n    $SqlBatch=[pscustomobject][Ordered]@{\r\n    StartOffset = $Batch.StartOffset;\r\n    StopOffset  = $Batch.StartOffset+$Batch.FragmentLength;\r\n    Length      = $Batch.FragmentLength;\r\n    StartColumn = $Batch.StartColumn;\r\n    BatchId     = $id;\r\n    BlockType   = \u0027Code\u0027;\r\n    Text        = $s.Substring($Batch.StartOffset, $Batch.FragmentLength)\r\n    }\r\n    $SqlBatches+=$SqlBatch\r\n    $id++\r\n}\r\n\r\n$ScriptFrags = Get-ScriptFragment -ScriptPath $ScriptToParse\r\n$Comments = @()\r\n$Comment = @()\r\nforeach($Frag in $ScriptFrags ) {\r\n    $Comment=[pscustomobject][Ordered]@{\r\n    StartOffset = $Frag.Offset;\r\n    StopOffset = $Frag.Offset+$Frag.Text.Length;\r\n    Length = $Frag.Text.Length;\r\n    StartColumn = $Frag.Column;\r\n    CommentLocation = $null;\r\n    BlockType = \u0027Comment\u0027;\r\n    Text = $Frag.Text\r\n    }\r\n\r\n    foreach($SqlBatch in $SqlBatches){\r\n\r\n    if($Comment.StartOffset -ge $SqlBatch.StartOffset -and $Comment.StartOffset -le $SqlBatch.StopOffset)\r\n    {$Comment.CommentLocation = \"Within SQL Batch $($SqlBatch.BatchId)\"}\r\n    else {if($Comment.CommentLocation -notlike \u0027*Within*\u0027){$Comment.CommentLocation = \"Outside\"}}\r\n    }\r\n    $Comments+=$Comment\r\n}"
+               ],
+    "metadata":  {
+                     "azdata_cell_guid":  "0171128c-163b-4355-81bf-416fa945d393"
+                 },
+    "outputs":  [
+                    {
+                        "name":  "stdout",
+                        "output_type":  "stream",
+                        "text":  ""
+                    }
+                ]
+},{"cell_type":"markdown","metadata":{},"source":["\u003c#################################################################################################\r   \n  This is the basic product.\r   \n  #################################################################################################\u003e"]},{
+    "cell_type":  "code",
+    "source":  [
+                   "$NotebookBlocks = $SqlBatches + ($Comments | WHERE { $_.CommentLocation -eq \u0027Outside\u0027 })\r\n$NotebookBlocks | SORT StartOffset\r\n}"
+               ],
+    "metadata":  {
+                     "azdata_cell_guid":  "26282d59-e102-4198-bb32-350ef9aa80ef"
+                 },
+    "outputs":  [
+                    {
+                        "name":  "stdout",
+                        "output_type":  "stream",
+                        "text":  ""
+                    }
+                ]
+}
+    ]
+}

--- a/__tests__/GoodConvertedNotebooks/ParsingExamples.ipynb
+++ b/__tests__/GoodConvertedNotebooks/ParsingExamples.ipynb
@@ -1,0 +1,79 @@
+﻿{
+    "metadata": {
+        "kernelspec": {
+            "name": "powershell",
+            "display_name": "PowerShell"
+        },
+        "language_info": {
+            "name": "powershell",
+            "codemirror_mode": "shell",
+            "mimetype": "text/x-sh",
+            "file_extension": ".ps1"
+        }
+    },
+    "nbformat_minor": 2,
+    "nbformat": 4,
+    "cells": [
+        {"cell_type":"markdown","metadata":{},"source":["# # This is file is an example of what _should_ happen when converting a .PS1 file to a .IPYNB file."]},{
+    "cell_type":  "code",
+    "source":  [
+                   "ps | select -first 10"
+               ],
+    "metadata":  {
+                     "azdata_cell_guid":  "60e9849a-c22f-4efc-9b52-e31a6365d550"
+                 },
+    "outputs":  [
+                    {
+                        "name":  "stdout",
+                        "output_type":  "stream",
+                        "text":  ""
+                    }
+                ]
+},{"cell_type":"markdown","metadata":{},"source":["# Get first 10 services"]},{
+    "cell_type":  "code",
+    "source":  [
+                   "gsv | select -first 10"
+               ],
+    "metadata":  {
+                     "azdata_cell_guid":  "b32ad383-0f0d-4141-93df-153bc4da9a8d"
+                 },
+    "outputs":  [
+                    {
+                        "name":  "stdout",
+                        "output_type":  "stream",
+                        "text":  ""
+                    }
+                ]
+},{"cell_type":"markdown","metadata":{},"source":["# Create a function"]},{
+    "cell_type":  "code",
+    "source":  [
+                   "function SayHello($p) {\"Hello $p\"}"
+               ],
+    "metadata":  {
+                     "azdata_cell_guid":  "46ded967-d569-48e7-a2c2-a41f8b32c0d2"
+                 },
+    "outputs":  [
+                    {
+                        "name":  "stdout",
+                        "output_type":  "stream",
+                        "text":  ""
+                    }
+                ]
+},{"cell_type":"markdown","metadata":{},"source":["# Use the function"]},{
+    "cell_type":  "code",
+    "source":  [
+                   "SayHello World"
+               ],
+    "metadata":  {
+                     "azdata_cell_guid":  "3093f59a-75be-464e-9789-7d1dd7cdc276"
+                 },
+    "outputs":  [
+                    {
+                        "name":  "stdout",
+                        "output_type":  "stream",
+                        "text":  ""
+                    }
+                ]
+}
+    ]
+}

--- a/__tests__/GoodConvertedNotebooks/demo.ipynb
+++ b/__tests__/GoodConvertedNotebooks/demo.ipynb
@@ -1,0 +1,79 @@
+﻿{
+    "metadata": {
+        "kernelspec": {
+            "name": "powershell",
+            "display_name": "PowerShell"
+        },
+        "language_info": {
+            "name": "powershell",
+            "codemirror_mode": "shell",
+            "mimetype": "text/x-sh",
+            "file_extension": ".ps1"
+        }
+    },
+    "nbformat_minor": 2,
+    "nbformat": 4,
+    "cells": [
+        {"cell_type":"markdown","metadata":{},"source":["# Get first 10 process"]},{
+    "cell_type":  "code",
+    "source":  [
+                   "ps | select -first 10"
+               ],
+    "metadata":  {
+                     "azdata_cell_guid":  "094bb95b-99c7-4236-aae1-394f5f7ccd55"
+                 },
+    "outputs":  [
+                    {
+                        "name":  "stdout",
+                        "output_type":  "stream",
+                        "text":  ""
+                    }
+                ]
+},{"cell_type":"markdown","metadata":{},"source":["# Get first 10 services"]},{
+    "cell_type":  "code",
+    "source":  [
+                   "gsv | select -first 10"
+               ],
+    "metadata":  {
+                     "azdata_cell_guid":  "9e31a902-e17a-4f15-b324-afc980cb82ab"
+                 },
+    "outputs":  [
+                    {
+                        "name":  "stdout",
+                        "output_type":  "stream",
+                        "text":  ""
+                    }
+                ]
+},{"cell_type":"markdown","metadata":{},"source":["# Create a function"]},{
+    "cell_type":  "code",
+    "source":  [
+                   "function SayHello($p) {\"Hello $p\"}"
+               ],
+    "metadata":  {
+                     "azdata_cell_guid":  "b3725f67-2847-44b3-a4b8-abd5b0d5b78e"
+                 },
+    "outputs":  [
+                    {
+                        "name":  "stdout",
+                        "output_type":  "stream",
+                        "text":  ""
+                    }
+                ]
+},{"cell_type":"markdown","metadata":{},"source":["# Use the function"]},{
+    "cell_type":  "code",
+    "source":  [
+                   "SayHello World"
+               ],
+    "metadata":  {
+                     "azdata_cell_guid":  "87b41c5a-f000-401a-b806-c156e7c6c059"
+                 },
+    "outputs":  [
+                    {
+                        "name":  "stdout",
+                        "output_type":  "stream",
+                        "text":  ""
+                    }
+                ]
+}
+    ]
+}

--- a/__tests__/GoodNotebooks/demo.ipynb
+++ b/__tests__/GoodNotebooks/demo.ipynb
@@ -1,0 +1,98 @@
+{
+    "metadata": {
+        "kernelspec": {
+            "name": "powershell",
+            "display_name": "PowerShell"
+        },
+        "language_info": {
+            "name": "powershell",
+            "codemirror_mode": "shell",
+            "mimetype": "text/x-sh",
+            "file_extension": ".ps1"
+        }
+    },
+    "nbformat_minor": 2,
+    "nbformat": 4,
+    "cells": [
+        {
+            "cell_type": "markdown",
+            "source": [
+                "Get first 10 process"
+            ],
+            "metadata": {
+                "azdata_cell_guid": "e04ff489-861c-46da-b13d-ebc686bd7d90"
+            }
+        },
+        {
+            "cell_type": "code",
+            "source": [
+                "ps | select -first 10"
+            ],
+            "metadata": {
+                "azdata_cell_guid": "bd9e51f5-e9c7-4784-bab4-f873692deb97"
+            },
+            "outputs": [],
+            "execution_count": null
+        },
+        {
+            "cell_type": "markdown",
+            "source": [
+                "Get first 10 services"
+            ],
+            "metadata": {
+                "azdata_cell_guid": "05f8b72a-674c-4f94-a233-14f4ff078d3c"
+            }
+        },
+        {
+            "cell_type": "code",
+            "source": [
+                "gsv | select -first 10"
+            ],
+            "metadata": {
+                "azdata_cell_guid": "93670f13-708f-42ce-b804-d0a25cdd3eb7"
+            },
+            "outputs": [],
+            "execution_count": null
+        },
+        {
+            "cell_type": "markdown",
+            "source": [
+                "Create a function"
+            ],
+            "metadata": {
+                "azdata_cell_guid": "94f6b887-f5f3-4275-bee4-fbfde27efa5d"
+            }
+        },
+        {
+            "cell_type": "code",
+            "source": [
+                "function SayHello($p) {\"Hello $p\"}"
+            ],
+            "metadata": {
+                "azdata_cell_guid": "c63c950f-a629-4bd3-bc9b-3be9b79c43fa"
+            },
+            "outputs": [],
+            "execution_count": null
+        },
+        {
+            "cell_type": "markdown",
+            "source": [
+                "Use the function"
+            ],
+            "metadata": {
+                "azdata_cell_guid": "bbd33eb6-5e62-439d-a7c5-7f141d00335a"
+            }
+        },
+        {
+            "cell_type": "code",
+            "source": [
+                "SayHello World"
+            ],
+            "metadata": {
+                "azdata_cell_guid": "92eb1f8a-01d8-4b30-af9f-56c25b728eb5"
+            },
+            "outputs": [],
+            "execution_count": null
+        }
+    ]
+}


### PR DESCRIPTION
This represents a first attempt of very basic logic around converting multi-line PowerShell statements within .PS1 files into into single code blocks in a Jupyter Notebook.  The previous logic worked off the assumption that sequential lines of PowerShell code (from the .PS1 file) were destined to be separate code cells in the Notebook (.IPYNB file).  

This simple logic uses `System.Management.Automation.PSParser` to Tokenize the PowerShell file and return the Start[ing position] and Length of all ASTs that are single-line comments or multi-line comments.  It then assumes that everything else in the file is PowerShell code (bad assumption, yes I know, be we have to start somewhere) and coverts the blocks to `text` (markdown) & `code` cells, respectively.

Again, this is very basic logic, but it is better than the previous code which would split 30 consecutive lines of PowerShell code into 30 separate code cells in the Notebook, instead of potentially keeping them together as a single code block of 30 lines.