### PR TITLE
Batch skipping comments

### DIFF
--- a/__tests__/ConvertToSQLNotebook.tests.ps1
+++ b/__tests__/ConvertToSQLNotebook.tests.ps1
@@ -28,6 +28,7 @@ SELECT * FROM table2 WHERE id = 1
 SELECT * FROM table3 where ID = 7
 /* Test3 */
 SELECT * FROM table4 where ID = 8'
+            $actual.Count | Should -Be 1
         }
         catch [System.Management.Automation.RuntimeException]{
             Write-Verbose "Runtime exception encountered" -Verbose

--- a/__tests__/ConvertToSQLNotebook.tests.ps1
+++ b/__tests__/ConvertToSQLNotebook.tests.ps1
@@ -1,16 +1,43 @@
 Import-Module $PSScriptRoot\..\PowerShellNotebook.psm1 -Force
 
 Describe "Test ConvertTo-SQLNoteBook" {
-    It "Should convert the file to an ipynb" {
+    It "Should convert the file to an ipynb with a single code cell" {
         $demoTextFile = "$PSScriptRoot\DemoFiles\demo.sql"
-        $fullName = "C:\temp\sqlTestConverted.ipnyb"
+        $fullName = "C:\temp\sqlTestConverted.ipynb"
 
         try{
             ConvertTo-SQLNoteBook -InputFileName $demoTextFile -OutputNotebookName $fullName
-            { Test-Pat $fullName } | Should Be $true
+            { Test-Path $fullName } | Should Be $true
 
             $actual = Get-NotebookContent -NoteBookFullName $fullName
-            $actual.Count | Should Be 7
+            $actual.Count | Should Be 1
+
+            $actual = Get-NotebookContent -NoteBookFullName $fullName -JustCode
+
+            $actual.Count | Should Be 1
+            write-verbose "tests $($actual[0].Source)" -Verbose
+            $actual[0].Source | Should -BeLike '*table3*'
+
+            $actual = Get-NotebookContent -NoteBookFullName $fullName -JustMarkdown
+
+            $actual.Count | Should Be 0
+        }
+        catch [System.Management.Automation.RuntimeException]{
+            Write-Verbose "Runtime exception encountered" -Verbose
+            Write-Verbose $_ -Verbose
+            throw
+        }
+    }
+    It "Should convert the file to an ipynb with 3 code and 6 text cells" {
+        $demoTextFile = "$PSScriptRoot\DemoFiles\demo_w3GOs.sql"
+        $fullName = "C:\temp\sqlTestConverted_demo_w3GOs.ipynb"
+
+        try{
+            ConvertTo-SQLNoteBook -InputFileName $demoTextFile -OutputNotebookName $fullName
+            { Test-Path $fullName } | Should Be $true
+
+            $actual = Get-NotebookContent -NoteBookFullName $fullName
+            $actual.Count | Should Be 9
 
             $actual = Get-NotebookContent -NoteBookFullName $fullName -JustCode
 
@@ -21,11 +48,13 @@ Describe "Test ConvertTo-SQLNoteBook" {
 
             $actual = Get-NotebookContent -NoteBookFullName $fullName -JustMarkdown
 
-            $actual.Count | Should Be 4
-            $actual[0].Source.Trim() | Should BeExactly 'Test1'
-            $actual[1].Source.Trim() | Should -BeLike '*Multiline test*'
-            $actual[2].Source.Trim() | Should BeExactly 'Test2'
-            $actual[3].Source.Trim() | Should BeExactly 'Test3'
+            $actual.Count | Should Be 6
+            $actual[0].Source.Trim() | Should BeExactly 'GO'
+            $actual[1].Source.Trim() | Should BeExactly 'Test1'
+            $actual[2].Source.Trim() | Should -BeLike '*Multiline test*'
+            $actual[3].Source.Trim() | Should BeExactly 'Test2'
+            $actual[4].Source.Trim() | Should BeExactly 'GO'
+            $actual[5].Source.Trim() | Should BeExactly 'Test3'
         }
         catch [System.Management.Automation.RuntimeException]{
             Write-Verbose "Runtime exception encountered" -Verbose

--- a/__tests__/ConvertToSQLNotebook.tests.ps1
+++ b/__tests__/ConvertToSQLNotebook.tests.ps1
@@ -9,9 +9,6 @@ Describe "Test ConvertTo-SQLNoteBook" {
             ConvertTo-SQLNoteBook -InputFileName $demoTextFile -OutputNotebookName $fullName
             { Test-Path $fullName } | Should Be $true
 
-            $actual = Get-NotebookContent -NoteBookFullName $fullName
-            $actual.Count | Should Be 1
-
             $actual = Get-NotebookContent -NoteBookFullName $fullName -JustMarkdown
 
             $actual.Count | Should Be 0

--- a/__tests__/ConvertToSQLNotebook.tests.ps1
+++ b/__tests__/ConvertToSQLNotebook.tests.ps1
@@ -9,12 +9,16 @@ Describe "Test ConvertTo-SQLNoteBook" {
             ConvertTo-SQLNoteBook -InputFileName $demoTextFile -OutputNotebookName $fullName
             { Test-Path $fullName } | Should Be $true
 
+            $actual = Get-NotebookContent -NoteBookFullName $fullName
+            $actual.Source.Count | Should Be 1
+
             $actual = Get-NotebookContent -NoteBookFullName $fullName -JustMarkdown
 
             $actual.Count | Should Be 0
 
             $actual = Get-NotebookContent -NoteBookFullName $fullName -JustCode
 
+            $actual.Count | Should Be 1
             write-verbose "tests $($actual[0].Source)" -Verbose
             $actual[0].Source | Should -BeLike '*table3*'
         }

--- a/__tests__/ConvertToSQLNotebook.tests.ps1
+++ b/__tests__/ConvertToSQLNotebook.tests.ps1
@@ -9,9 +9,6 @@ Describe "Test ConvertTo-SQLNoteBook" {
             ConvertTo-SQLNoteBook -InputFileName $demoTextFile -OutputNotebookName $fullName
             { Test-Path $fullName } | Should Be $true
 
-            $actual = Get-NotebookContent -NoteBookFullName $fullName
-            $actual.Source.Count | Should Be 1
-
             $actual = Get-NotebookContent -NoteBookFullName $fullName -JustMarkdown
 
             $actual.Count | Should Be 0

--- a/__tests__/ConvertToSQLNotebook.tests.ps1
+++ b/__tests__/ConvertToSQLNotebook.tests.ps1
@@ -3,7 +3,7 @@ Import-Module $PSScriptRoot\..\PowerShellNotebook.psm1 -Force
 Describe "Test ConvertTo-SQLNoteBook" {
     It "Should convert the file to an ipynb with a single code cell" {
         $demoTextFile = "$PSScriptRoot\DemoFiles\demo.sql"
-        $fullName = "C:\temp\sqlTestConverted.ipynb"
+        $fullName = "TestDrive:\sqlTestConverted.ipynb"
 
         try{
             ConvertTo-SQLNoteBook -InputFileName $demoTextFile -OutputNotebookName $fullName

--- a/__tests__/ConvertToSQLNotebook.tests.ps1
+++ b/__tests__/ConvertToSQLNotebook.tests.ps1
@@ -18,7 +18,6 @@ Describe "Test ConvertTo-SQLNoteBook" {
 
             $actual = Get-NotebookContent -NoteBookFullName $fullName -JustCode
 
-            $actual.Count | Should Be 1
             write-verbose "tests $($actual[0].Source)" -Verbose
             $actual[0].Source | Should -BeLike '*table3*'
         }

--- a/__tests__/ConvertToSQLNotebook.tests.ps1
+++ b/__tests__/ConvertToSQLNotebook.tests.ps1
@@ -28,7 +28,6 @@ SELECT * FROM table2 WHERE id = 1
 SELECT * FROM table3 where ID = 7
 /* Test3 */
 SELECT * FROM table4 where ID = 8'
-            $actual.Count | Should -Be 1
         }
         catch [System.Management.Automation.RuntimeException]{
             Write-Verbose "Runtime exception encountered" -Verbose

--- a/__tests__/ConvertToSQLNotebook.tests.ps1
+++ b/__tests__/ConvertToSQLNotebook.tests.ps1
@@ -17,6 +17,17 @@ Describe "Test ConvertTo-SQLNoteBook" {
 
             write-verbose "tests $($actual[0].Source)" -Verbose
             $actual[0].Source | Should -BeLike '*table3*'
+            $actual[0].Source | Should -BeExactly 'select DateDiff(MI,StartDate,EndDate) AS Timetaken,* FROM table1
+SELECT * FROM table2 WHERE id = 1
+/* Test1 */
+/* Multiline test
+1
+2
+*/
+/* Test2 */
+SELECT * FROM table3 where ID = 7
+/* Test3 */
+SELECT * FROM table4 where ID = 8'
         }
         catch [System.Management.Automation.RuntimeException]{
             Write-Verbose "Runtime exception encountered" -Verbose

--- a/__tests__/ConvertToSQLNotebook.tests.ps1
+++ b/__tests__/ConvertToSQLNotebook.tests.ps1
@@ -15,7 +15,6 @@ Describe "Test ConvertTo-SQLNoteBook" {
 
             $actual = Get-NotebookContent -NoteBookFullName $fullName -JustCode
 
-            $actual.Count | Should Be 1
             write-verbose "tests $($actual[0].Source)" -Verbose
             $actual[0].Source | Should -BeLike '*table3*'
         }

--- a/__tests__/ConvertToSQLNotebook.tests.ps1
+++ b/__tests__/ConvertToSQLNotebook.tests.ps1
@@ -12,15 +12,15 @@ Describe "Test ConvertTo-SQLNoteBook" {
             $actual = Get-NotebookContent -NoteBookFullName $fullName
             $actual.Count | Should Be 1
 
+            $actual = Get-NotebookContent -NoteBookFullName $fullName -JustMarkdown
+
+            $actual.Count | Should Be 0
+
             $actual = Get-NotebookContent -NoteBookFullName $fullName -JustCode
 
             $actual.Count | Should Be 1
             write-verbose "tests $($actual[0].Source)" -Verbose
             $actual[0].Source | Should -BeLike '*table3*'
-
-            $actual = Get-NotebookContent -NoteBookFullName $fullName -JustMarkdown
-
-            $actual.Count | Should Be 0
         }
         catch [System.Management.Automation.RuntimeException]{
             Write-Verbose "Runtime exception encountered" -Verbose

--- a/__tests__/DemoFiles/AdventureWorksMultiStatementSBatch_NoGO2.sql
+++ b/__tests__/DemoFiles/AdventureWorksMultiStatementSBatch_NoGO2.sql
@@ -1,0 +1,90 @@
+/* Look up user and phone number by last name
+We match on first found in case of multiple
+*/
+declare @phonenumber nvarchar(50)
+declare @lastname nvarchar(50)
+declare @busentityid INT
+
+set @lastname = 'Tamburello'
+
+select 
+top 1
+@busentityid = BusinessEntityID -- Will be used to lookup phone number
+from Person.Person
+where LastName = @lastname
+
+/* Only look for phone if we found the person
+-- Should usually be null or 1, values over 1 not really possible
+*/
+if @busentityid is not null
+begin
+
+   select 
+      p.FirstName,
+      p.MiddleName,
+      p.LastName,
+      p.Suffix,
+      pp.PhoneNumber
+   from 
+      Person.Person p
+      left join Person.PersonPhone pp
+      on p.BusinessEntityID = pp.BusinessEntityID
+   where 
+      p.BusinessEntityID = @busentityid
+
+/* Save the phonenumber from the selected user */
+   select 
+      @phonenumber = PhoneNumber 
+   from 
+      Person.Person p
+      left join Person.PersonPhone pp
+      on p.BusinessEntityID = pp.BusinessEntityID
+   where
+      p.BusinessEntityID = @busentityid
+
+end
+
+go 
+
+-- Wait for 4 seconds total after go 2
+RAISERROR('waiting', 1,1) with nowait
+select GETUTCDATE() as 'Waiting'
+waitfor delay '00:00:02'
+
+-- note the Go 2 has been *removed*
+go
+
+-- This select statement returns the full customer address list
+select 
+    p.FirstName,
+    p.MiddleName,
+    p.LastName,
+    p.Suffix,
+    a.AddressLine1,
+    a.AddressLine2,  -- TODO: Should we concat line 1 and 2
+    a.City,
+    /*
+    Debug stuff
+    p.BusinessEntityID,
+    bea.BusinessEntityID,
+    bea.AddressID,
+    a.AddressiD,
+    sp.StateProvinceID,
+    sp.StateProvinceID
+    */
+    sp.StateProvinceCode, /* TODO: Need to add country here too, join below */
+    a.PostalCode--,
+    --sp.CountryRegionCode 
+ from 
+    Person.Person p
+    left join Person.BusinessEntityAddress bea  -- Used for joining, not selected from
+    on p.BusinessEntityID = bea.BusinessEntityID 
+    left join Person.Address a 
+    on bea.AddressID = a.AddressID
+    left join Person.StateProvince sp 
+    on a.StateProvinceID = sp.StateProvinceID
+    /* Commenting out until the field is added
+    left join Person.CountryRegion cr 
+    on sp.CountryRegionCode = cr.CountryRegionCode
+    */
+

--- a/__tests__/DemoFiles/demo_w3GOs.sql
+++ b/__tests__/DemoFiles/demo_w3GOs.sql
@@ -1,0 +1,13 @@
+select DateDiff(MI,StartDate,EndDate) AS Timetaken,* FROM table1
+SELECT * FROM table2 WHERE id = 1
+GO
+/* Test1 */
+/* Multiline test
+1
+2
+*/
+/* Test2 */
+SELECT * FROM table3 where ID = 7
+GO
+/* Test3 */
+SELECT * FROM table4 where ID = 8

--- a/__tests__/GoodConvertedNotebooks/AdventureWorksMultiStatementSBatch_NoGO2.ipynb
+++ b/__tests__/GoodConvertedNotebooks/AdventureWorksMultiStatementSBatch_NoGO2.ipynb
@@ -1,0 +1,94 @@
+﻿{
+    "metadata": {
+        "kernelspec": {
+            "name": "sql",
+            "display_name": "SQL"
+        },
+        "language_info": {
+            "name": "sql",
+            "codemirror_mode": "shell",
+            "mimetype": "text/x-sh",
+            "file_extension": ".sql"
+        }
+    },
+    "nbformat_minor": 2,
+    "nbformat": 4,
+    "cells": [
+        {"cell_type":"markdown","metadata":{},"source":[" Look up user and phone number by last name\r   \n  We match on first found in case of multiple\r   \n  "]},{
+    "cell_type":  "code",
+    "source":  [
+                   "\r\ndeclare @phonenumber nvarchar(50)\r\ndeclare @lastname nvarchar(50)\r\ndeclare @busentityid INT\r\n\r\nset @lastname = \u0027Tamburello\u0027\r\n\r\nselect \r\ntop 1\r\n@busentityid = BusinessEntityID -- Will be used to lookup phone number\r\nfrom Person.Person\r\nwhere LastName = @lastname\r\n\r\n"
+               ],
+    "metadata":  {
+                     "azdata_cell_guid":  "e62ad53e-ff64-49e9-acd2-71d455ac47c6"
+                 },
+    "outputs":  [
+                    {
+                        "name":  "stdout",
+                        "output_type":  "stream",
+                        "text":  ""
+                    }
+                ]
+},{"cell_type":"markdown","metadata":{},"source":[" Only look for phone if we found the person\r   \n  -- Should usually be null or 1, values over 1 not really possible\r   \n  "]},{
+    "cell_type":  "code",
+    "source":  [
+                   "\r\nif @busentityid is not null\r\nbegin\r\n\r\n   select \r\n      p.FirstName,\r\n      p.MiddleName,\r\n      p.LastName,\r\n      p.Suffix,\r\n      pp.PhoneNumber\r\n   from \r\n      Person.Person p\r\n      left join Person.PersonPhone pp\r\n      on p.BusinessEntityID = pp.BusinessEntityID\r\n   where \r\n      p.BusinessEntityID = @busentityid\r\n\r\n"
+               ],
+    "metadata":  {
+                     "azdata_cell_guid":  "9e5e7e23-d114-4c6f-bad4-bebc1791a47a"
+                 },
+    "outputs":  [
+                    {
+                        "name":  "stdout",
+                        "output_type":  "stream",
+                        "text":  ""
+                    }
+                ]
+},{"cell_type":"markdown","metadata":{},"source":[" Save the phonenumber from the selected user "]},{
+    "cell_type":  "code",
+    "source":  [
+                   "\r\n   select \r\n      @phonenumber = PhoneNumber \r\n   from \r\n      Person.Person p\r\n      left join Person.PersonPhone pp\r\n      on p.BusinessEntityID = pp.BusinessEntityID\r\n   where\r\n      p.BusinessEntityID = @busentityid\r\n\r\nend\r\n\r\ngo \r\n\r\n-- Wait for 4 seconds total after go 2\r\nRAISERROR(\u0027waiting\u0027, 1,1) with nowait\r\nselect GETUTCDATE() as \u0027Waiting\u0027\r\nwaitfor delay \u002700:00:02\u0027\r\n\r\n-- note the Go 2\r\ngo\r\n\r\n-- This select statement returns the full customer address list\r\nselect \r\n    p.FirstName,\r\n    p.MiddleName,\r\n    p.LastName,\r\n    p.Suffix,\r\n    a.AddressLine1,\r\n    a.AddressLine2,  -- TODO: Should we concat line 1 and 2\r\n    a.City,\r\n    "
+               ],
+    "metadata":  {
+                     "azdata_cell_guid":  "dcec6698-df18-48d1-9301-080c11a4e48b"
+                 },
+    "outputs":  [
+                    {
+                        "name":  "stdout",
+                        "output_type":  "stream",
+                        "text":  ""
+                    }
+                ]
+},{"cell_type":"markdown","metadata":{},"source":["\r   \n      Debug stuff\r   \n      p.BusinessEntityID,\r   \n      bea.BusinessEntityID,\r   \n      bea.AddressID,\r   \n      a.AddressiD,\r   \n      sp.StateProvinceID,\r   \n      sp.StateProvinceID\r   \n      "]},{
+    "cell_type":  "code",
+    "source":  [
+                   "\r\n    sp.StateProvinceCode, "
+               ],
+    "metadata":  {
+                     "azdata_cell_guid":  "ce67717d-a7ff-4710-8d24-a129831c6cd2"
+                 },
+    "outputs":  [
+                    {
+                        "name":  "stdout",
+                        "output_type":  "stream",
+                        "text":  ""
+                    }
+                ]
+},{"cell_type":"markdown","metadata":{},"source":[" TODO: Need to add country here too, join below "]},{
+    "cell_type":  "code",
+    "source":  [
+                   "\r\n    a.PostalCode--,\r\n    --sp.CountryRegionCode \r\n from \r\n    Person.Person p\r\n    left join Person.BusinessEntityAddress bea  -- Used for joining, not selected from\r\n    on p.BusinessEntityID = bea.BusinessEntityID \r\n    left join Person.Address a \r\n    on bea.AddressID = a.AddressID\r\n    left join Person.StateProvince sp \r\n    on a.StateProvinceID = sp.StateProvinceID\r\n    "
+               ],
+    "metadata":  {
+                     "azdata_cell_guid":  "401fab4b-69ac-46d7-9ca6-5e13eca3321e"
+                 },
+    "outputs":  [
+                    {
+                        "name":  "stdout",
+                        "output_type":  "stream",
+                        "text":  ""
+                    }
+                ]
+},{"cell_type":"markdown","metadata":{},"source":[" Commenting out until the field is added\r   \n      left join Person.CountryRegion cr \r   \n      on sp.CountryRegionCode = cr.CountryRegionCode\r   \n      "]}
+    ]
+}

--- a/__tests__/GoodConvertedNotebooks/AdventureWorksMultiStatementSBatch_NoGO2.ipynb
+++ b/__tests__/GoodConvertedNotebooks/AdventureWorksMultiStatementSBatch_NoGO2.ipynb
@@ -1,4 +1,4 @@
-﻿{
+{
     "metadata": {
         "kernelspec": {
             "name": "sql",
@@ -14,81 +14,51 @@
     "nbformat_minor": 2,
     "nbformat": 4,
     "cells": [
-        {"cell_type":"markdown","metadata":{},"source":[" Look up user and phone number by last name\r   \n  We match on first found in case of multiple\r   \n  "]},{
-    "cell_type":  "code",
-    "source":  [
-                   "\r\ndeclare @phonenumber nvarchar(50)\r\ndeclare @lastname nvarchar(50)\r\ndeclare @busentityid INT\r\n\r\nset @lastname = \u0027Tamburello\u0027\r\n\r\nselect \r\ntop 1\r\n@busentityid = BusinessEntityID -- Will be used to lookup phone number\r\nfrom Person.Person\r\nwhere LastName = @lastname\r\n\r\n"
-               ],
-    "metadata":  {
-                     "azdata_cell_guid":  "e62ad53e-ff64-49e9-acd2-71d455ac47c6"
-                 },
-    "outputs":  [
-                    {
-                        "name":  "stdout",
-                        "output_type":  "stream",
-                        "text":  ""
-                    }
-                ]
-},{"cell_type":"markdown","metadata":{},"source":[" Only look for phone if we found the person\r   \n  -- Should usually be null or 1, values over 1 not really possible\r   \n  "]},{
-    "cell_type":  "code",
-    "source":  [
-                   "\r\nif @busentityid is not null\r\nbegin\r\n\r\n   select \r\n      p.FirstName,\r\n      p.MiddleName,\r\n      p.LastName,\r\n      p.Suffix,\r\n      pp.PhoneNumber\r\n   from \r\n      Person.Person p\r\n      left join Person.PersonPhone pp\r\n      on p.BusinessEntityID = pp.BusinessEntityID\r\n   where \r\n      p.BusinessEntityID = @busentityid\r\n\r\n"
-               ],
-    "metadata":  {
-                     "azdata_cell_guid":  "9e5e7e23-d114-4c6f-bad4-bebc1791a47a"
-                 },
-    "outputs":  [
-                    {
-                        "name":  "stdout",
-                        "output_type":  "stream",
-                        "text":  ""
-                    }
-                ]
-},{"cell_type":"markdown","metadata":{},"source":[" Save the phonenumber from the selected user "]},{
-    "cell_type":  "code",
-    "source":  [
-                   "\r\n   select \r\n      @phonenumber = PhoneNumber \r\n   from \r\n      Person.Person p\r\n      left join Person.PersonPhone pp\r\n      on p.BusinessEntityID = pp.BusinessEntityID\r\n   where\r\n      p.BusinessEntityID = @busentityid\r\n\r\nend\r\n\r\ngo \r\n\r\n-- Wait for 4 seconds total after go 2\r\nRAISERROR(\u0027waiting\u0027, 1,1) with nowait\r\nselect GETUTCDATE() as \u0027Waiting\u0027\r\nwaitfor delay \u002700:00:02\u0027\r\n\r\n-- note the Go 2\r\ngo\r\n\r\n-- This select statement returns the full customer address list\r\nselect \r\n    p.FirstName,\r\n    p.MiddleName,\r\n    p.LastName,\r\n    p.Suffix,\r\n    a.AddressLine1,\r\n    a.AddressLine2,  -- TODO: Should we concat line 1 and 2\r\n    a.City,\r\n    "
-               ],
-    "metadata":  {
-                     "azdata_cell_guid":  "dcec6698-df18-48d1-9301-080c11a4e48b"
-                 },
-    "outputs":  [
-                    {
-                        "name":  "stdout",
-                        "output_type":  "stream",
-                        "text":  ""
-                    }
-                ]
-},{"cell_type":"markdown","metadata":{},"source":["\r   \n      Debug stuff\r   \n      p.BusinessEntityID,\r   \n      bea.BusinessEntityID,\r   \n      bea.AddressID,\r   \n      a.AddressiD,\r   \n      sp.StateProvinceID,\r   \n      sp.StateProvinceID\r   \n      "]},{
-    "cell_type":  "code",
-    "source":  [
-                   "\r\n    sp.StateProvinceCode, "
-               ],
-    "metadata":  {
-                     "azdata_cell_guid":  "ce67717d-a7ff-4710-8d24-a129831c6cd2"
-                 },
-    "outputs":  [
-                    {
-                        "name":  "stdout",
-                        "output_type":  "stream",
-                        "text":  ""
-                    }
-                ]
-},{"cell_type":"markdown","metadata":{},"source":[" TODO: Need to add country here too, join below "]},{
-    "cell_type":  "code",
-    "source":  [
-                   "\r\n    a.PostalCode--,\r\n    --sp.CountryRegionCode \r\n from \r\n    Person.Person p\r\n    left join Person.BusinessEntityAddress bea  -- Used for joining, not selected from\r\n    on p.BusinessEntityID = bea.BusinessEntityID \r\n    left join Person.Address a \r\n    on bea.AddressID = a.AddressID\r\n    left join Person.StateProvince sp \r\n    on a.StateProvinceID = sp.StateProvinceID\r\n    "
-               ],
-    "metadata":  {
-                     "azdata_cell_guid":  "401fab4b-69ac-46d7-9ca6-5e13eca3321e"
-                 },
-    "outputs":  [
-                    {
-                        "name":  "stdout",
-                        "output_type":  "stream",
-                        "text":  ""
-                    }
-                ]
-},{"cell_type":"markdown","metadata":{},"source":[" Commenting out until the field is added\r   \n      left join Person.CountryRegion cr \r   \n      on sp.CountryRegionCode = cr.CountryRegionCode\r   \n      "]}
+        {"cell_type":"markdown","metadata":{},"source":[" Look up user and phone number by last name   \n  We match on first found in case of multiple   \n  "]},{
+  "cell_type": "code",
+  "source": [
+    "declare @phonenumber nvarchar(50)\r\ndeclare @lastname nvarchar(50)\r\ndeclare @busentityid INT\r\n\r\nset @lastname = 'Tamburello'\r\n\r\nselect \r\ntop 1\r\n@busentityid = BusinessEntityID -- Will be used to lookup phone number\r\nfrom Person.Person\r\nwhere LastName = @lastname\r\n\r\n/* Only look for phone if we found the person\r\n-- Should usually be null or 1, values over 1 not really possible\r\n*/\r\nif @busentityid is not null\r\nbegin\r\n\r\n   select \r\n      p.FirstName,\r\n      p.MiddleName,\r\n      p.LastName,\r\n      p.Suffix,\r\n      pp.PhoneNumber\r\n   from \r\n      Person.Person p\r\n      left join Person.PersonPhone pp\r\n      on p.BusinessEntityID = pp.BusinessEntityID\r\n   where \r\n      p.BusinessEntityID = @busentityid\r\n\r\n/* Save the phonenumber from the selected user */\r\n   select \r\n      @phonenumber = PhoneNumber \r\n   from \r\n      Person.Person p\r\n      left join Person.PersonPhone pp\r\n      on p.BusinessEntityID = pp.BusinessEntityID\r\n   where\r\n      p.BusinessEntityID = @busentityid\r\n\r\nend"
+  ],
+  "metadata": {
+    "azdata_cell_guid": "729e42ae-3c57-48a9-890b-768c6982b64c"
+  },
+  "outputs": [
+    {
+      "output_type": "stream",
+      "name": "stdout",
+      "text": ""
+    }
+  ]
+},{"cell_type":"markdown","metadata":{},"source":["go \r   \n  \r   \n  -- Wait for 4 seconds total after go 2"]},{
+  "cell_type": "code",
+  "source": [
+    "RAISERROR('waiting', 1,1) with nowait\r\nselect GETUTCDATE() as 'Waiting'\r\nwaitfor delay '00:00:02'"
+  ],
+  "metadata": {
+    "azdata_cell_guid": "65bde348-4a0b-4c91-8ced-b91c84c42ec9"
+  },
+  "outputs": [
+    {
+      "output_type": "stream",
+      "name": "stdout",
+      "text": ""
+    }
+  ]
+},{"cell_type":"markdown","metadata":{},"source":["-- note the Go 2 has been *removed*\r   \n  go\r   \n  \r   \n  -- This select statement returns the full customer address list"]},{
+  "cell_type": "code",
+  "source": [
+    "select \r\n    p.FirstName,\r\n    p.MiddleName,\r\n    p.LastName,\r\n    p.Suffix,\r\n    a.AddressLine1,\r\n    a.AddressLine2,  -- TODO: Should we concat line 1 and 2\r\n    a.City,\r\n    /*\r\n    Debug stuff\r\n    p.BusinessEntityID,\r\n    bea.BusinessEntityID,\r\n    bea.AddressID,\r\n    a.AddressiD,\r\n    sp.StateProvinceID,\r\n    sp.StateProvinceID\r\n    */\r\n    sp.StateProvinceCode, /* TODO: Need to add country here too, join below */\r\n    a.PostalCode--,\r\n    --sp.CountryRegionCode \r\n from \r\n    Person.Person p\r\n    left join Person.BusinessEntityAddress bea  -- Used for joining, not selected from\r\n    on p.BusinessEntityID = bea.BusinessEntityID \r\n    left join Person.Address a \r\n    on bea.AddressID = a.AddressID\r\n    left join Person.StateProvince sp \r\n    on a.StateProvinceID = sp.StateProvinceID"
+  ],
+  "metadata": {
+    "azdata_cell_guid": "aba3de77-b194-45f4-ba4c-7af9cac92a93"
+  },
+  "outputs": [
+    {
+      "output_type": "stream",
+      "name": "stdout",
+      "text": ""
+    }
+  ]
+},{"cell_type":"markdown","metadata":{},"source":[" Commenting out until the field is added   \n      left join Person.CountryRegion cr    \n      on sp.CountryRegionCode = cr.CountryRegionCode   \n      "]}
     ]
 }

--- a/__tests__/GoodConvertedNotebooks/sqlTestConverted.ipynb
+++ b/__tests__/GoodConvertedNotebooks/sqlTestConverted.ipynb
@@ -1,0 +1,64 @@
+{
+    "metadata": {
+        "kernelspec": {
+            "name": "sql",
+            "display_name": "SQL"
+        },
+        "language_info": {
+            "name": "sql",
+            "codemirror_mode": "shell",
+            "mimetype": "text/x-sh",
+            "file_extension": ".sql"
+        }
+    },
+    "nbformat_minor": 2,
+    "nbformat": 4,
+    "cells": [
+        {
+  "cell_type": "code",
+  "source": [
+    "select DateDiff(MI,StartDate,EndDate) AS Timetaken,* FROM table1\r\nSELECT * FROM table2 WHERE id = 1"
+  ],
+  "metadata": {
+    "azdata_cell_guid": "0f2f0f31-fa05-41c7-bb20-1f83f234ee3e"
+  },
+  "outputs": [
+    {
+      "output_type": "stream",
+      "name": "stdout",
+      "text": ""
+    }
+  ]
+},{"cell_type":"markdown","metadata":{},"source":["GO"]},{"cell_type":"markdown","metadata":{},"source":[" Test1 "]},{"cell_type":"markdown","metadata":{},"source":[" Multiline test   \n  1   \n  2   \n  "]},{"cell_type":"markdown","metadata":{},"source":[" Test2 "]},{
+  "cell_type": "code",
+  "source": [
+    "SELECT * FROM table3 where ID = 7"
+  ],
+  "metadata": {
+    "azdata_cell_guid": "0dd78d7e-d3f7-42f9-b4c4-d4eabd617f36"
+  },
+  "outputs": [
+    {
+      "output_type": "stream",
+      "name": "stdout",
+      "text": ""
+    }
+  ]
+},{"cell_type":"markdown","metadata":{},"source":["GO"]},{"cell_type":"markdown","metadata":{},"source":[" Test3 "]},{
+  "cell_type": "code",
+  "source": [
+    "SELECT * FROM table4 where ID = 8"
+  ],
+  "metadata": {
+    "azdata_cell_guid": "6f46d7c8-7c8f-4945-8995-95a90f1ba3ab"
+  },
+  "outputs": [
+    {
+      "output_type": "stream",
+      "name": "stdout",
+      "text": ""
+    }
+  ]
+}
+    ]
+}


### PR DESCRIPTION
Added logic to leverage ScriptDom to know when to **not** extract a comment from within a batch.  This additional step in beneficial because it avoids breaking a single piece of SQL code up into two (or more) code cells that are separated by one (or more) text cells.  A stored procedure with a multi-line comment in the middle is a perfect example of something that will not work in the Jupyter Notebooks using the old logic, but will work properly using the new logic, because it will go into a single code cell.

This additional logic broke the original test, so that test was rewritten to correctly detect the resulting .IPYNB file using the new logic.  In addition, a second test was added using a slightly different SQL file (`demo_w3GOs.sql`) to detect specifics about how the new logic should properly output the code & text cells to the Jupyter Notebook.

Finally, additional assets were added to the project (`AdventureWorksMultiStatementSBatch_NoGO2.sql` & `AdventureWorksMultiStatementSBatch_NoGO2.ipynb`) as good examples of what a good conversion of a more complex SQL file should look like.  If time allows in the future, additional tests could be built around the `AdventureWorksMultiStatementSBatch_NoGO2.ipynb` file.