### PR TITLE
Corrected error for single Batch SQL file

### DIFF
--- a/ConvertToSQLNoteBook.ps1
+++ b/ConvertToSQLNoteBook.ps1
@@ -80,7 +80,7 @@ if($ExtractCommentsInsideBatches){
     $ExtractAllComments = $Comments
 }
 else {
-    $ExtractAllComments = $Comments | WHERE { $_.CommentLocation -eq 'Outside' }
+    $ExtractAllComments = $Comments | Where-Object { $_.CommentLocation -eq 'Outside' }
 }
 $NotebookBlocks = $SqlBatches + $ExtractAllComments
 

--- a/ConvertToSQLNoteBook.ps1
+++ b/ConvertToSQLNoteBook.ps1
@@ -146,10 +146,10 @@ else {
 
                 $Previous=$GapOffsets
                 $AllBlocks+=if($GapOffsets.Length -gt 2){[pscustomobject] $GapOffsets}
+                }
             }
             #$AllBlocks | SORT StartOffset | ft -AutoSize -Wrap
             return $AllBlocks
-            }
         }
     }
 }

--- a/ConvertToSQLNoteBook.ps1
+++ b/ConvertToSQLNoteBook.ps1
@@ -77,10 +77,10 @@ This is the basic product of Mulit-line Coments that are outside of Batches.
 Can you detect parameters in a test?
 #################################################################################################>
 if($ExtractCommentsInsideBatches){
-    $ExtractAllComments = $Comments | WHERE { $_.CommentLocation -eq 'Outside' }
+    $ExtractAllComments = $Comments
 }
 else {
-    $ExtractAllComments = $Comments
+    $ExtractAllComments = $Comments | WHERE { $_.CommentLocation -eq 'Outside' }
 }
 $NotebookBlocks = $SqlBatches + $ExtractAllComments
 

--- a/__tests__/ConvertToSQLNotebook.tests.ps1
+++ b/__tests__/ConvertToSQLNotebook.tests.ps1
@@ -43,7 +43,7 @@ SELECT * FROM table4 where ID = 8'
     }
     It "Should convert the file to an ipynb with 3 code and 6 text cells" {
         $demoTextFile = "$PSScriptRoot\DemoFiles\demo_w3GOs.sql"
-        $fullName = "C:\temp\sqlTestConverted_demo_w3GOs.ipynb"
+        $fullName = "TestDrive:\sqlTestConverted_demo_w3GOs.ipynb"
 
         try{
             ConvertTo-SQLNoteBook -InputFileName $demoTextFile -OutputNotebookName $fullName
@@ -68,6 +68,38 @@ SELECT * FROM table4 where ID = 8'
             $actual[3].Source.Trim() | Should BeExactly 'Test2'
             $actual[4].Source.Trim() | Should BeExactly 'GO'
             $actual[5].Source.Trim() | Should BeExactly 'Test3'
+        }
+        catch [System.Management.Automation.RuntimeException]{
+            Write-Verbose "Runtime exception encountered" -Verbose
+            Write-Verbose $_ -Verbose
+            throw
+        }
+    }
+    It "Should convert the file to an ipynb with 3 code and 6 text cells" {
+        $demoTextFile = "$PSScriptRoot\DemoFiles\AdventureWorksMultiStatementSBatch_NoGO2.sql"
+        $fullName = "TestDrive:\AdventureWorksMultiStatementSBatch_NoGO2.ipynb"
+
+        try{
+            ConvertTo-SQLNoteBook -InputFileName $demoTextFile -OutputNotebookName $fullName
+            { Test-Path $fullName } | Should -Be $true
+
+            $actual = Get-NotebookContent -NoteBookFullName $fullName
+            $actual.Count | Should -Be 7
+
+            $actual = Get-NotebookContent -NoteBookFullName $fullName -JustCode
+
+            $actual.Count | Should -Be 3
+            write-verbose "Code cells: $($actual.Count)" -Verbose
+            $actual[0].Source | Should -BeLike '*Person.PersonPhone*'
+            $actual[1].Source | Should -BeLike '*GETUTCDATE*'
+
+            $actual = Get-NotebookContent -NoteBookFullName $fullName -JustMarkdown
+
+            $actual.Count | Should -Be 4
+            $actual[0].Source.Trim() | Should -BeLike 'Look up user and phone number by last name*'
+            $actual[1].Source.Trim() | Should -BeLike '*-- Wait for 4 seconds total after go 2'
+            $actual[2].Source.Trim() | Should -BeLike '*note the Go 2 has been*'
+            $actual[3].Source.Trim() | Should -BeLike 'Commenting out until the field is added*'
         }
         catch [System.Management.Automation.RuntimeException]{
             Write-Verbose "Runtime exception encountered" -Verbose

--- a/__tests__/GetParsedSqlOffsets.tests.ps1
+++ b/__tests__/GetParsedSqlOffsets.tests.ps1
@@ -12,15 +12,14 @@ Describe "Test Get-ParsedSqlOffsets" {
 
             @($Offsets).Count | Should -Be 1
 
-            $Offsets = (Get-ParsedSqlOffsets -ScriptPath $demoTextFile).where({$_.BlockType -ne 'Code'})
+            $Offsets = Get-ParsedSqlOffsets -ScriptPath $demoTextFile | Where-Object {$_.BlockType -ne 'Code'}
 
             $Offsets.Count | Should -Be 0
 
-            $Offsets = (Get-ParsedSqlOffsets -ScriptPath $demoTextFile).where({$_.BlockType -eq 'Code'})
+            $Offsets = Get-ParsedSqlOffsets -ScriptPath $demoTextFile | Where-Object {$_.BlockType -eq 'Code'}
 
             @($Offsets).Count | Should -Be 1
 
-            write-verbose "tests $($Offsets[0].Source)" -Verbose
             $Offsets[0].Text | Should -BeExactly 'select DateDiff(MI,StartDate,EndDate) AS Timetaken,* FROM table1
 SELECT * FROM table2 WHERE id = 1
 /* Test1 */
@@ -68,7 +67,7 @@ SELECT * FROM table4 where ID = 8'
             throw
         }
     }
-    It "Should retrieve the Batch, Comment, and Gap offsets with 3 code and 6 text cells" {
+    It "Should retrieve the Batch, Comment, and Gap offsets with 3 code and 5 text cells" {
         $demoTextFile = "$PSScriptRoot\DemoFiles\AdventureWorksMultiStatementSBatch_NoGO2.sql"
         $fullName = "TestDrive:\AdventureWorksMultiStatementSBatch_NoGO2.csv"
 

--- a/__tests__/GetParsedSqlOffsets.tests.ps1
+++ b/__tests__/GetParsedSqlOffsets.tests.ps1
@@ -1,0 +1,100 @@
+Import-Module $PSScriptRoot\..\PowerShellNotebook.psm1 -Force
+
+Describe "Test Get-ParsedSqlOffsets" {
+    It "Should retrieve the Batch, Comment, and Gap offsets with a single code cell" {
+        $demoTextFile = "$PSScriptRoot\DemoFiles\demo.sql"
+        $fullName = "TestDrive:\demosql.csv"
+
+        try{
+            $Offsets = Get-ParsedSqlOffsets -ScriptPath $demoTextFile
+            $Offsets | ConvertTo-Csv -NoTypeInformation > $fullName
+            { Test-Path $fullName } | Should Be $true
+
+            @($Offsets).Count | Should -Be 1
+
+            $Offsets = (Get-ParsedSqlOffsets -ScriptPath $demoTextFile).where({$_.BlockType -ne 'Code'})
+
+            $Offsets.Count | Should -Be 0
+
+            $Offsets = (Get-ParsedSqlOffsets -ScriptPath $demoTextFile).where({$_.BlockType -eq 'Code'})
+
+            @($Offsets).Count | Should -Be 1
+
+            write-verbose "tests $($Offsets[0].Source)" -Verbose
+            $Offsets[0].Text | Should -BeExactly 'select DateDiff(MI,StartDate,EndDate) AS Timetaken,* FROM table1
+SELECT * FROM table2 WHERE id = 1
+/* Test1 */
+/* Multiline test
+1
+2
+*/
+/* Test2 */
+SELECT * FROM table3 where ID = 7
+/* Test3 */
+SELECT * FROM table4 where ID = 8'
+        }
+        catch [System.Management.Automation.RuntimeException]{
+            Write-Verbose "Runtime exception encountered" -Verbose
+            Write-Verbose $_ -Verbose
+            throw
+        }
+    }
+    It "Should retrieve the Batch, Comment, and Gap offsets with 3 code and 6 text cells" {
+        $demoTextFile = "$PSScriptRoot\DemoFiles\demo_w3GOs.sql"
+        $fullName = "TestDrive:\sqlTestConverted_demo_w3GOs.csv"
+
+        try{
+            $Offsets = Get-ParsedSqlOffsets -ScriptPath $demoTextFile
+            $Offsets | ConvertTo-Csv -NoTypeInformation > $fullName
+            { Test-Path $fullName } | Should -Be $true
+
+            @($Offsets).Count | Should -Be 9
+
+            $Offsets = (Get-ParsedSqlOffsets -ScriptPath $demoTextFile).where({$_.BlockType -eq 'Comment'})
+
+            $Offsets.Count | Should -Be 4
+
+            $Offsets = (Get-ParsedSqlOffsets -ScriptPath $demoTextFile).where({$_.BlockType -eq 'Gap'})
+
+            $Offsets.Count | Should -Be 2
+
+            $Offsets = (Get-ParsedSqlOffsets -ScriptPath $demoTextFile).where({$_.BlockType -eq 'Code'})
+
+            $Offsets.Count | Should -Be 3
+        }
+        catch [System.Management.Automation.RuntimeException]{
+            Write-Verbose "Runtime exception encountered" -Verbose
+            Write-Verbose $_ -Verbose
+            throw
+        }
+    }
+    It "Should retrieve the Batch, Comment, and Gap offsets with 3 code and 6 text cells" {
+        $demoTextFile = "$PSScriptRoot\DemoFiles\AdventureWorksMultiStatementSBatch_NoGO2.sql"
+        $fullName = "TestDrive:\AdventureWorksMultiStatementSBatch_NoGO2.csv"
+
+        try{
+            $Offsets = Get-ParsedSqlOffsets -ScriptPath $demoTextFile
+            $Offsets | ConvertTo-Csv -NoTypeInformation > $fullName
+            { Test-Path $fullName } | Should -Be $true
+
+            @($Offsets).Count | Should -Be 8
+
+            $Offsets = (Get-ParsedSqlOffsets -ScriptPath $demoTextFile).where({$_.BlockType -eq 'Comment'})
+
+            $Offsets.Count | Should -Be 2
+
+            $Offsets = (Get-ParsedSqlOffsets -ScriptPath $demoTextFile).where({$_.BlockType -eq 'Gap'})
+
+            $Offsets.Count | Should -Be 3
+
+            $Offsets = (Get-ParsedSqlOffsets -ScriptPath $demoTextFile).where({$_.BlockType -eq 'Code'})
+
+            $Offsets.Count | Should -Be 3
+        }
+        catch [System.Management.Automation.RuntimeException]{
+            Write-Verbose "Runtime exception encountered" -Verbose
+            Write-Verbose $_ -Verbose
+            throw
+        }
+    }
+}


### PR DESCRIPTION
An error was occurring when a .SQL file with only a single batch was being converted.
> `Method invocation failed because [System.Management.Automation.PSObject] does not contain a method named 'op_Addition'`

The piece of code causing this was `$AllBlocks+=if($GapOffsets.Length -gt 2){[pscustomobject] $GapOffsets}`

The error occurred because `+=` does not play well with two `PSCustomObjects`

Add an `if` prior to the `foreach` section to skip the `foreach` section if the parsing results had only returned a single batch.