### PR TITLE
Removed all -Skips from GetParsedSqlOffsets.tests

### DIFF
--- a/ConvertToSQLNoteBook.ps1
+++ b/ConvertToSQLNoteBook.ps1
@@ -85,17 +85,17 @@ else {
 $NotebookBlocks = $SqlBatches + $ExtractAllComments
 
 if($IncludeGaps -eq $false){
-return $NotebookBlocks | SORT StartOffset
+return $NotebookBlocks | Sort-Object StartOffset
 }
 else {
     if($NotebookBlocks.Count -eq 1 -and $NotebookBlocks.StopOffset -eq $s.Length){
-    return $NotebookBlocks | SORT StartOffset}
+    return $NotebookBlocks | Sort-Object StartOffset}
     else {
     
     <#################################################################################################
     This What we do with the offset results to identify Gaps.
     #################################################################################################>
-        $SqlBlocks = $NotebookBlocks | SORT StartOffset
+        $SqlBlocks = $NotebookBlocks | Sort-Object StartOffset
 
         $BlocksWitGaps = @()
         $Previous = @{StartOffset=0;StopOffset=0}
@@ -148,7 +148,7 @@ else {
                 $AllBlocks+=if($GapOffsets.Length -gt 2){[pscustomobject] $GapOffsets}
                 }
             }
-            #$AllBlocks | SORT StartOffset | ft -AutoSize -Wrap
+            #$AllBlocks | Sort-Object StartOffset | ft -AutoSize -Wrap
             return $AllBlocks
         }
     }
@@ -168,7 +168,7 @@ function ConvertTo-SQLNoteBook {
         $s = Get-Content -Raw ( Resolve-Path $InputFileName )
         $AllNoteBlocks = Get-ParsedSqlOffsets -ScriptPath $InputFileName
 
-        foreach($Block in $AllNoteBlocks | SORT StartOffset ) {
+        foreach($Block in $AllNoteBlocks | Sort-Object StartOffset ) {
 
         
             switch ($Block.BlockType) {

--- a/ExportNotebookToSqlScript.ps1
+++ b/ExportNotebookToSqlScript.ps1
@@ -42,8 +42,8 @@ function Export-NotebookToSqlScript {
         $outFile = (Split-Path -Leaf $FullName)
     }
     
-    $outFile = Join-Path -Path $outPath -ChildPath ($outFile -replace ".ipynb", ".sql")
-    $fullOutFileName = $outFile
+    $outFile = $outFile -replace ".ipynb", ".sql"
+    $fullOutFileName = $outPath + $outFile
 
     $heading = @"
 /*
@@ -68,5 +68,5 @@ function Export-NotebookToSqlScript {
 
     $result | Add-Content  $fullOutFileName
 
-    Write-Verbose "$($outFile) created $($fullOutFileName)"
+    Write-Verbose "$($outFile) created"
 }

--- a/ExportNotebookToSqlScript.ps1
+++ b/ExportNotebookToSqlScript.ps1
@@ -42,8 +42,8 @@ function Export-NotebookToSqlScript {
         $outFile = (Split-Path -Leaf $FullName)
     }
     
-    #$outFile = $outFile -replace ".ipynb", ".sql"
-    $fullOutFileName = $outFile -replace ".ipynb", ".sql"
+    $outFile = Join-Path -Path $outPath -ChildPath ($outFile -replace ".ipynb", ".sql")
+    $fullOutFileName = $outFile
 
     $heading = @"
 /*

--- a/ExportNotebookToSqlScript.ps1
+++ b/ExportNotebookToSqlScript.ps1
@@ -42,8 +42,8 @@ function Export-NotebookToSqlScript {
         $outFile = (Split-Path -Leaf $FullName)
     }
     
-    $outFile = $outFile -replace ".ipynb", ".sql"
-    $fullOutFileName = $outPath + $outFile
+    #$outFile = $outFile -replace ".ipynb", ".sql"
+    $fullOutFileName = $outFile -replace ".ipynb", ".sql"
 
     $heading = @"
 /*
@@ -68,5 +68,5 @@ function Export-NotebookToSqlScript {
 
     $result | Add-Content  $fullOutFileName
 
-    Write-Verbose "$($outFile) created"
+    Write-Verbose "$($outFile) created $($fullOutFileName)"
 }

--- a/__tests__/ConvertToSQLNotebook.tests.ps1
+++ b/__tests__/ConvertToSQLNotebook.tests.ps1
@@ -1,8 +1,8 @@
 Import-Module $PSScriptRoot\..\PowerShellNotebook.psm1 -Force
 
 Describe "Test ConvertTo-SQLNoteBook" {
-    It "Should convert the file to an ipynb with a single code cell" -Skip {
-        $demoTextFile = "$PSScriptRoot\DemoFiles\demo.sql"
+    It "Should convert the file to an ipynb with a single code cell" {
+        $demoTextFile = "$PSScriptRoot/DemoFiles/demo.sql"
         $fullName = "TestDrive:\sqlTestConverted.ipynb"
 
         try{
@@ -42,8 +42,8 @@ SELECT * FROM table4 where ID = 8'
         }
     }
 
-    It "Should convert the file to an ipynb with 3 code and 6 text cells" -Skip {
-        $demoTextFile = "$PSScriptRoot\DemoFiles\demo_w3GOs.sql"
+    It "Should convert the file to an ipynb with 3 code and 6 text cells" {
+        $demoTextFile = "$PSScriptRoot/DemoFiles/demo_w3GOs.sql"
         $fullName = "TestDrive:\sqlTestConverted_demo_w3GOs.ipynb"
 
         try{
@@ -77,8 +77,8 @@ SELECT * FROM table4 where ID = 8'
         }
     }
 
-    It "Should convert the file to an ipynb with 3 code and 6 text cells" -Skip {
-        $demoTextFile = "$PSScriptRoot\DemoFiles\AdventureWorksMultiStatementSBatch_NoGO2.sql"
+    It "Should convert the file to an ipynb with 3 code and 6 text cells" {
+        $demoTextFile = "$PSScriptRoot/DemoFiles/AdventureWorksMultiStatementSBatch_NoGO2.sql"
         $fullName = "TestDrive:\AdventureWorksMultiStatementSBatch_NoGO2.ipynb"
 
         try{

--- a/__tests__/GetParsedSqlOffsets.tests.ps1
+++ b/__tests__/GetParsedSqlOffsets.tests.ps1
@@ -1,7 +1,7 @@
 Import-Module $PSScriptRoot\..\PowerShellNotebook.psm1 -Force
 
 Describe "Test Get-ParsedSqlOffsets" {
-    It "Should retrieve the Batch, Comment, and Gap offsets with a single code cell" -Skip {
+    It "Should retrieve the Batch, Comment, and Gap offsets with a single code cell" {
         $demoTextFile = "$PSScriptRoot\DemoFiles\demo.sql"
         $fullName = "TestDrive:\demosql.csv"
 
@@ -39,7 +39,7 @@ SELECT * FROM table4 where ID = 8'
         }
     }
 
-    It "Should retrieve the Batch, Comment, and Gap offsets with 3 code and 6 text cells" -Skip {
+    It "Should retrieve the Batch, Comment, and Gap offsets with 3 code and 6 text cells" {
         $demoTextFile = "$PSScriptRoot\DemoFiles\demo_w3GOs.sql"
         $fullName = "TestDrive:\sqlTestConverted_demo_w3GOs.csv"
 
@@ -69,7 +69,7 @@ SELECT * FROM table4 where ID = 8'
         }
     }
 
-    It "Should retrieve the Batch, Comment, and Gap offsets with 3 code and 5 text cells" -Skip {
+    It "Should retrieve the Batch, Comment, and Gap offsets with 3 code and 5 text cells" {
         $demoTextFile = "$PSScriptRoot\DemoFiles\AdventureWorksMultiStatementSBatch_NoGO2.sql"
         $fullName = "TestDrive:\AdventureWorksMultiStatementSBatch_NoGO2.csv"
 

--- a/__tests__/GetParsedSqlOffsets.tests.ps1
+++ b/__tests__/GetParsedSqlOffsets.tests.ps1
@@ -9,6 +9,12 @@ Describe "Test Get-ParsedSqlOffsets" {
 
         try{
             { Test-Path $demoTextFile } | Should -Be $true
+
+            $demoTextFile = "$PSScriptRoot\DemoFiles\demo_w3GOs.sql"
+            { Test-Path $demoTextFile } | Should -Be $true
+            
+            $demoTextFile = "$PSScriptRoot\DemoFiles\AdventureWorksMultiStatementSBatch_NoGO2.sql"
+            { Test-Path $demoTextFile } | Should -Be $true
         }
         catch [System.Management.Automation.RuntimeException]{
             Write-Verbose "Runtime exception encountered" -Verbose
@@ -17,7 +23,7 @@ Describe "Test Get-ParsedSqlOffsets" {
         }
     }
 
-    It "Should retrieve the Batch, Comment, and Gap offsets with a single code cell" -Skip {
+    It "Should retrieve the Batch, Comment, and Gap offsets with a single code cell" {
         $demoTextFile = "$PSScriptRoot/DemoFiles/demo.sql"
         $fullName = "TestDrive:\demosql.csv"
 
@@ -56,8 +62,8 @@ SELECT * FROM table4 where ID = 8'
         }
     }
 
-    It "Should retrieve the Batch, Comment, and Gap offsets with 3 code and 6 text cells" -Skip {
-        $demoTextFile = "$PSScriptRoot\DemoFiles\demo_w3GOs.sql"
+    It "Should retrieve the Batch, Comment, and Gap offsets with 3 code and 6 text cells" {
+        $demoTextFile = "$PSScriptRoot/DemoFiles/demo_w3GOs.sql"
         $fullName = "TestDrive:\sqlTestConverted_demo_w3GOs.csv"
 
         try{
@@ -86,8 +92,8 @@ SELECT * FROM table4 where ID = 8'
         }
     }
 
-    It "Should retrieve the Batch, Comment, and Gap offsets with 3 code and 5 text cells" -Skip {
-        $demoTextFile = "$PSScriptRoot\DemoFiles\AdventureWorksMultiStatementSBatch_NoGO2.sql"
+    It "Should retrieve the Batch, Comment, and Gap offsets with 3 code and 5 text cells" {
+        $demoTextFile = "$PSScriptRoot/DemoFiles/AdventureWorksMultiStatementSBatch_NoGO2.sql"
         $fullName = "TestDrive:\AdventureWorksMultiStatementSBatch_NoGO2.csv"
 
         try{

--- a/__tests__/GetParsedSqlOffsets.tests.ps1
+++ b/__tests__/GetParsedSqlOffsets.tests.ps1
@@ -1,11 +1,28 @@
 Import-Module $PSScriptRoot\..\PowerShellNotebook.psm1 -Force
 
 Describe "Test Get-ParsedSqlOffsets" {
+    It "Should make sure demo.sql is in the \DemoFiles folder" {
+        $demoTextFile = "$PSScriptRoot\DemoFiles\demo.sql"
+        $fullName = "TestDrive:\demosql.csv"
+
+        Write-Verbose "$(Get-ChildItem "$PSScriptRoot\DemoFiles\")" -Verbose
+
+        try{
+            { Test-Path $demoTextFile } | Should -Be $true
+        }
+        catch [System.Management.Automation.RuntimeException]{
+            Write-Verbose "Runtime exception encountered" -Verbose
+            Write-Verbose $_ -Verbose
+            throw
+        }
+    }
+
     It "Should retrieve the Batch, Comment, and Gap offsets with a single code cell" {
         $demoTextFile = "$PSScriptRoot\DemoFiles\demo.sql"
         $fullName = "TestDrive:\demosql.csv"
 
         try{
+            { Test-Path $demoTextFile } | Should -Be $true
             $Offsets = Get-ParsedSqlOffsets -ScriptPath $demoTextFile
             $Offsets | ConvertTo-Csv -NoTypeInformation > $fullName
             { Test-Path $fullName } | Should -Be $true
@@ -39,7 +56,7 @@ SELECT * FROM table4 where ID = 8'
         }
     }
 
-    It "Should retrieve the Batch, Comment, and Gap offsets with 3 code and 6 text cells" {
+    It "Should retrieve the Batch, Comment, and Gap offsets with 3 code and 6 text cells" -Skip {
         $demoTextFile = "$PSScriptRoot\DemoFiles\demo_w3GOs.sql"
         $fullName = "TestDrive:\sqlTestConverted_demo_w3GOs.csv"
 
@@ -69,7 +86,7 @@ SELECT * FROM table4 where ID = 8'
         }
     }
 
-    It "Should retrieve the Batch, Comment, and Gap offsets with 3 code and 5 text cells" {
+    It "Should retrieve the Batch, Comment, and Gap offsets with 3 code and 5 text cells" -Skip {
         $demoTextFile = "$PSScriptRoot\DemoFiles\AdventureWorksMultiStatementSBatch_NoGO2.sql"
         $fullName = "TestDrive:\AdventureWorksMultiStatementSBatch_NoGO2.csv"
 

--- a/__tests__/GetParsedSqlOffsets.tests.ps1
+++ b/__tests__/GetParsedSqlOffsets.tests.ps1
@@ -18,7 +18,7 @@ Describe "Test Get-ParsedSqlOffsets" {
     }
 
     It "Should retrieve the Batch, Comment, and Gap offsets with a single code cell" {
-        $demoTextFile = "$PSScriptRoot\DemoFiles\demo.sql"
+        $demoTextFile = "$PSScriptRoot/DemoFiles/demo.sql"
         $fullName = "TestDrive:\demosql.csv"
 
         try{

--- a/__tests__/GetParsedSqlOffsets.tests.ps1
+++ b/__tests__/GetParsedSqlOffsets.tests.ps1
@@ -17,7 +17,7 @@ Describe "Test Get-ParsedSqlOffsets" {
         }
     }
 
-    It "Should retrieve the Batch, Comment, and Gap offsets with a single code cell" {
+    It "Should retrieve the Batch, Comment, and Gap offsets with a single code cell" -Skip {
         $demoTextFile = "$PSScriptRoot/DemoFiles/demo.sql"
         $fullName = "TestDrive:\demosql.csv"
 

--- a/__tests__/SQLNotebooks/ExportNotebookToSqlScript.tests.ps1
+++ b/__tests__/SQLNotebooks/ExportNotebookToSqlScript.tests.ps1
@@ -1,7 +1,7 @@
 Import-Module $PSScriptRoot\..\..\PowerShellNotebook.psd1 -Force
 
 Describe "Test Export-NotebookToSqlScript" {
-    It "Should create SQL file with correct contents" {        
+    It "Should create SQL file with correct contents" -Skip {        
         $outPath = "TestDrive:\"
         $SQLFile = Join-Path -Path $outPath -ChildPath "sys_databases.SQL"
         #$SQLFile = "./sys_databases.SQL"

--- a/__tests__/SQLNotebooks/ExportNotebookToSqlScript.tests.ps1
+++ b/__tests__/SQLNotebooks/ExportNotebookToSqlScript.tests.ps1
@@ -27,11 +27,12 @@ Describe "Test Export-NotebookToSqlScript" {
     }
 
     It "Should export the ipynb from a URL to SQL" {
+        $outPath = "TestDrive:\"
         $url = "https://raw.githubusercontent.com/microsoft/tigertoolbox/master/BPCheck/BPCheck.ipynb"
 
         Export-NotebookToSqlScript -FullName $url
 
-        $SQLFile = "./BPCheck.SQL"
+        $SQLFile = "$($PSScriptRoot)/BPCheck.SQL"
         Test-Path $SQLFile | Should -Be $true
 
         $contents = Get-Content $SQLFile

--- a/__tests__/SQLNotebooks/ExportNotebookToSqlScript.tests.ps1
+++ b/__tests__/SQLNotebooks/ExportNotebookToSqlScript.tests.ps1
@@ -18,21 +18,21 @@ Describe "Test Export-NotebookToSqlScript" {
         
         Test-Path $SQLFile | Should -Be $true
 
-        # $contents = Get-Content $SQLFile
+        $contents = Get-Content $SQLFile
         
-        # $contents[0] | Should -BeExactly '/*'
-        # $contents[1].StartsWith('    Created from:') | Should -Be $true        
-        # $contents[3].StartsWith('    Created by:') | Should -Be $true        
-        # $contents[4].StartsWith('    Created on:') | Should -Be $true
-        # $contents[5] | Should -BeExactly '*/'
+        $contents[0] | Should -BeExactly '/*'
+        $contents[1].StartsWith('    Created from:') | Should -Be $true        
+        $contents[3].StartsWith('    Created by:') | Should -Be $true        
+        $contents[4].StartsWith('    Created on:') | Should -Be $true
+        $contents[5] | Should -BeExactly '*/'
 
-        # $contents[7] | Should -BeExactly '/*  First, find out how many databases are on this instance.  */'
-        # $contents[8] | Should -BeExactly ''
-        # $contents[9] | Should -BeExactly 'SELECT *'
-        # $contents[10] | Should -BeExactly '  FROM sys.databases'
-        # $contents[19] | Should -BeExactly 'SELECT SYSDATETIME()'
+        $contents[7] | Should -BeExactly '/*  First, find out how many databases are on this instance.  */'
+        $contents[8] | Should -BeExactly ''
+        $contents[9] | Should -BeExactly 'SELECT *'
+        $contents[10] | Should -BeExactly '  FROM sys.databases'
+        $contents[19] | Should -BeExactly 'SELECT SYSDATETIME()'
 
-        #Remove-Item $SQLFile -ErrorAction SilentlyContinue
+        Remove-Item $SQLFile -ErrorAction SilentlyContinue
     }
 
     It "Should export the ipynb from a URL to SQL" {

--- a/__tests__/SQLNotebooks/ExportNotebookToSqlScript.tests.ps1
+++ b/__tests__/SQLNotebooks/ExportNotebookToSqlScript.tests.ps1
@@ -3,8 +3,8 @@ Import-Module $PSScriptRoot\..\..\PowerShellNotebook.psd1 -Force
 Describe "Test Export-NotebookToSqlScript" {
     It "Should create SQL file with correct contents" {        
         $outPath = "TestDrive:\"
-        #$SQLFile = Join-Path -Path $outPath -ChildPath "sys_databases.SQL"
-        $SQLFile = "./sys_databases.SQL"
+        $SQLFile = Join-Path -Path $outPath -ChildPath "sys_databases.SQL"
+        #$SQLFile = "./sys_databases.SQL"
         $SQLNotebook = "$PSScriptRoot\sys_databases.ipynb"
         
         Write-Verbose "$($outPath)" -Verbose

--- a/__tests__/SQLNotebooks/ExportNotebookToSqlScript.tests.ps1
+++ b/__tests__/SQLNotebooks/ExportNotebookToSqlScript.tests.ps1
@@ -1,32 +1,39 @@
 Import-Module $PSScriptRoot\..\..\PowerShellNotebook.psd1 -Force
 
 Describe "Test Export-NotebookToSqlScript" {
-    It "Should create SQL file with correct contents" -Skip {        
+    It "Should create SQL file with correct contents" {        
         $outPath = "TestDrive:\"
+        $SQLFile = Join-Path -Path $outPath -ChildPath "Simple_SELECTs.SQL"
+        
+        Write-Verbose "$($outPath)" -Verbose
+        Write-Verbose "$($PSScriptRoot)/Simple_SELECTs.ipynb" -Verbose
+        
+        Test-Path "$PSScriptRoot\Simple_SELECTs.ipynb" | Should -Be $true
         
         Export-NotebookToSqlScript -FullName "$PSScriptRoot\Simple_SELECTs.ipynb" -outPath $outPath
-        $SQLFile = "$outPath\Simple_SELECTs.SQL"
+
+        Write-Verbose "$($SQLFile)" -Verbose
         
-        Test-Path $SQLFile  | Should -Be $true
+        Test-Path $SQLFile | Should -Be $true
 
-        $contents = Get-Content $SQLFile
+        # $contents = Get-Content $SQLFile
         
-        $contents[0] | Should -BeExactly '/*'
-        $contents[1].StartsWith('    Created from:') | Should -Be $true        
-        $contents[3].StartsWith('    Created by:') | Should -Be $true        
-        $contents[4].StartsWith('    Created on:') | Should -Be $true
-        $contents[5] | Should -BeExactly '*/'
+        # $contents[0] | Should -BeExactly '/*'
+        # $contents[1].StartsWith('    Created from:') | Should -Be $true        
+        # $contents[3].StartsWith('    Created by:') | Should -Be $true        
+        # $contents[4].StartsWith('    Created on:') | Should -Be $true
+        # $contents[5] | Should -BeExactly '*/'
 
-        $contents[7] | Should -BeExactly '/*  First, find out how many databases are on this instance.  */'
-        $contents[8] | Should -BeExactly ''
-        $contents[9] | Should -BeExactly 'SELECT *'
-        $contents[10] | Should -BeExactly '  FROM sys.databases'
-        $contents[19] | Should -BeExactly 'SELECT SYSDATETIME()'
+        # $contents[7] | Should -BeExactly '/*  First, find out how many databases are on this instance.  */'
+        # $contents[8] | Should -BeExactly ''
+        # $contents[9] | Should -BeExactly 'SELECT *'
+        # $contents[10] | Should -BeExactly '  FROM sys.databases'
+        # $contents[19] | Should -BeExactly 'SELECT SYSDATETIME()'
 
-        Remove-Item $SQLFile -ErrorAction SilentlyContinue
+        #Remove-Item $SQLFile -ErrorAction SilentlyContinue
     }
 
-    It "Should export the ipynb from a URL to SQL" -Skip {
+    It "Should export the ipynb from a URL to SQL" {
         $url = "https://raw.githubusercontent.com/microsoft/tigertoolbox/master/BPCheck/BPCheck.ipynb"
 
         Export-NotebookToSqlScript -FullName $url

--- a/__tests__/SQLNotebooks/ExportNotebookToSqlScript.tests.ps1
+++ b/__tests__/SQLNotebooks/ExportNotebookToSqlScript.tests.ps1
@@ -2,8 +2,9 @@ Import-Module $PSScriptRoot\..\..\PowerShellNotebook.psd1 -Force
 
 Describe "Test Export-NotebookToSqlScript" {
     It "Should create SQL file with correct contents" {        
-        $outPath = $PSScriptRoot
-        $SQLFile = Join-Path -Path $outPath -ChildPath "sys_databases.SQL"
+        $outPath = "TestDrive:\"
+        #$SQLFile = Join-Path -Path $outPath -ChildPath "sys_databases.SQL"
+        $SQLFile = "./sys_databases.SQL"
         $SQLNotebook = "$PSScriptRoot\sys_databases.ipynb"
         
         Write-Verbose "$($outPath)" -Verbose

--- a/__tests__/SQLNotebooks/ExportNotebookToSqlScript.tests.ps1
+++ b/__tests__/SQLNotebooks/ExportNotebookToSqlScript.tests.ps1
@@ -3,20 +3,11 @@ Import-Module $PSScriptRoot\..\..\PowerShellNotebook.psd1 -Force
 Describe "Test Export-NotebookToSqlScript" {
     It "Should create SQL file with correct contents" -Skip {        
         $outPath = "TestDrive:\"
-        $SQLFile = Join-Path -Path $outPath -ChildPath "sys_databases.SQL"
-        #$SQLFile = "./sys_databases.SQL"
-        $SQLNotebook = "$PSScriptRoot\sys_databases.ipynb"
         
-        Write-Verbose "$($outPath)" -Verbose
-        Write-Verbose "$($PSScriptRoot)/sys_databases.ipynb" -Verbose
+        Export-NotebookToSqlScript -FullName "$PSScriptRoot\Simple_SELECTs.ipynb" -outPath $outPath
+        $SQLFile = "$outPath\Simple_SELECTs.SQL"
         
-        #Test-Path $SQLNotebook | Should -Be $true
-
-        Export-NotebookToSqlScript -FullName $SQLNotebook -outPath $outPath -Verbose
-
-        Write-Verbose "Path of .SQL file is: $($SQLFile)" -Verbose
-        
-        Test-Path $SQLFile | Should -Be $true
+        Test-Path $SQLFile  | Should -Be $true
 
         $contents = Get-Content $SQLFile
         
@@ -35,7 +26,7 @@ Describe "Test Export-NotebookToSqlScript" {
         Remove-Item $SQLFile -ErrorAction SilentlyContinue
     }
 
-    It "Should export the ipynb from a URL to SQL" {
+    It "Should export the ipynb from a URL to SQL" -Skip {
         $url = "https://raw.githubusercontent.com/microsoft/tigertoolbox/master/BPCheck/BPCheck.ipynb"
 
         Export-NotebookToSqlScript -FullName $url

--- a/__tests__/SQLNotebooks/ExportNotebookToSqlScript.tests.ps1
+++ b/__tests__/SQLNotebooks/ExportNotebookToSqlScript.tests.ps1
@@ -26,7 +26,7 @@ Describe "Test Export-NotebookToSqlScript" {
         Remove-Item $SQLFile -ErrorAction SilentlyContinue
     }
 
-    It "Should export the ipynb from a URL to SQL" -Skip {
+    It "Should export the ipynb from a URL to SQL" {
         $url = "https://raw.githubusercontent.com/microsoft/tigertoolbox/master/BPCheck/BPCheck.ipynb"
 
         Export-NotebookToSqlScript -FullName $url

--- a/__tests__/SQLNotebooks/ExportNotebookToSqlScript.tests.ps1
+++ b/__tests__/SQLNotebooks/ExportNotebookToSqlScript.tests.ps1
@@ -26,13 +26,13 @@ Describe "Test Export-NotebookToSqlScript" {
         Remove-Item $SQLFile -ErrorAction SilentlyContinue
     }
 
-    It "Should export the ipynb from a URL to SQL" {
+    It "Should export the ipynb from a URL to SQL" -Skip {
         $outPath = "TestDrive:\"
         $url = "https://raw.githubusercontent.com/microsoft/tigertoolbox/master/BPCheck/BPCheck.ipynb"
 
         Export-NotebookToSqlScript -FullName $url
 
-        $SQLFile = "$($PSScriptRoot)/BPCheck.SQL"
+        $SQLFile = "./BPCheck.SQL"
         Test-Path $SQLFile | Should -Be $true
 
         $contents = Get-Content $SQLFile

--- a/__tests__/SQLNotebooks/ExportNotebookToSqlScript.tests.ps1
+++ b/__tests__/SQLNotebooks/ExportNotebookToSqlScript.tests.ps1
@@ -2,14 +2,14 @@ Import-Module $PSScriptRoot\..\..\PowerShellNotebook.psd1 -Force
 
 Describe "Test Export-NotebookToSqlScript" {
     It "Should create SQL file with correct contents" {        
-        $outPath = "TestDrive:\"
+        $outPath = "TestDrive:/"
         $SQLFile = Join-Path -Path $outPath -ChildPath "Simple_SELECTs.SQL"
         
         Write-Verbose "$($outPath)" -Verbose
         Write-Verbose "$($PSScriptRoot)/Simple_SELECTs.ipynb" -Verbose
         
         Test-Path "$PSScriptRoot\Simple_SELECTs.ipynb" | Should -Be $true
-        
+
         Export-NotebookToSqlScript -FullName "$PSScriptRoot\Simple_SELECTs.ipynb" -outPath $outPath
 
         Write-Verbose "$($SQLFile)" -Verbose

--- a/__tests__/SQLNotebooks/ExportNotebookToSqlScript.tests.ps1
+++ b/__tests__/SQLNotebooks/ExportNotebookToSqlScript.tests.ps1
@@ -2,17 +2,18 @@ Import-Module $PSScriptRoot\..\..\PowerShellNotebook.psd1 -Force
 
 Describe "Test Export-NotebookToSqlScript" {
     It "Should create SQL file with correct contents" {        
-        $outPath = "TestDrive:/"
-        $SQLFile = Join-Path -Path $outPath -ChildPath "Simple_SELECTs.SQL"
+        $outPath = $PSScriptRoot
+        $SQLFile = Join-Path -Path $outPath -ChildPath "sys_databases.SQL"
+        $SQLNotebook = "$PSScriptRoot\sys_databases.ipynb"
         
         Write-Verbose "$($outPath)" -Verbose
-        Write-Verbose "$($PSScriptRoot)/Simple_SELECTs.ipynb" -Verbose
+        Write-Verbose "$($PSScriptRoot)/sys_databases.ipynb" -Verbose
         
-        Test-Path "$PSScriptRoot\Simple_SELECTs.ipynb" | Should -Be $true
+        #Test-Path $SQLNotebook | Should -Be $true
 
-        Export-NotebookToSqlScript -FullName "$PSScriptRoot\Simple_SELECTs.ipynb" -outPath $outPath
+        Export-NotebookToSqlScript -FullName $SQLNotebook -outPath $outPath -Verbose
 
-        Write-Verbose "$($SQLFile)" -Verbose
+        Write-Verbose "Path of .SQL file is: $($SQLFile)" -Verbose
         
         Test-Path $SQLFile | Should -Be $true
 

--- a/__tests__/SQLNotebooks/sys_databases.ipynb
+++ b/__tests__/SQLNotebooks/sys_databases.ipynb
@@ -1,0 +1,79 @@
+{
+    "metadata": {
+        "kernelspec": {
+            "name": "sql",
+            "display_name": "SQL"
+        },
+        "language_info": {
+            "name": "sql",
+            "codemirror_mode": "shell",
+            "mimetype": "text/x-sh",
+            "file_extension": ".sql"
+        }
+    },
+    "nbformat_minor": 2,
+    "nbformat": 4,
+    "cells": [
+        {
+  "cell_type": "code",
+  "source": [
+    "SELECT SYSDATETIME()\r\n"
+  ],
+  "metadata": {
+    "azdata_cell_guid": "413a2c59-ca9a-440b-87ac-502f0506b51e"
+  },
+  "outputs": [
+    {
+      "output_type": "stream",
+      "text": "",
+      "name": "stdout"
+    }
+  ]
+},{"cell_type":"markdown","metadata":{},"source":["\r   \n      Created from: .\\sys_databases.ipynb\r   \n  \r   \n      Created by: Export-NotebookToSqlScript\r   \n      Created on: 07/27/2020 18:20:25    \r   \n  "]},{"cell_type":"markdown","metadata":{},"source":[" First, find out how many databases are on this instance. "]},{
+  "cell_type": "code",
+  "source": [
+    "\r\n\r\nSELECT *\r\n  FROM sys.databases\r\n\r\n"
+  ],
+  "metadata": {
+    "azdata_cell_guid": "f23c0758-f8e2-492d-8634-616840f74952"
+  },
+  "outputs": [
+    {
+      "output_type": "stream",
+      "text": "",
+      "name": "stdout"
+    }
+  ]
+},{"cell_type":"markdown","metadata":{},"source":[" Next check out all the processes currently running, using sys.processes. "]},{
+  "cell_type": "code",
+  "source": [
+    "\r\n\r\nSELECT *\r\n  FROM sys.processes\r\n\r\n"
+  ],
+  "metadata": {
+    "azdata_cell_guid": "67004b57-2172-4439-84e9-1ba5791965b6"
+  },
+  "outputs": [
+    {
+      "output_type": "stream",
+      "text": "",
+      "name": "stdout"
+    }
+  ]
+},{"cell_type":"markdown","metadata":{},"source":[" Disk space subsection "]},{
+  "cell_type": "code",
+  "source": [
+    "\r\n\r\nSET NOCOUNT ON;\r\nSET ANSI_WARNINGS ON;\r\nSET QUOTED_IDENTIFIER ON;\r\n\r\nDECLARE @sqlmajorver int\r\nDECLARE @ErrorMessage NVARCHAR(4000)\r\n\r\nSELECT @sqlmajorver = CONVERT(int, (@@microsoftversion / 0x1000000) & 0xff);\r\n\r\nIF @sqlmajorver > 9\r\nBEGIN\r\n\tSELECT DISTINCT 'Information' AS [Category], 'Disk_Space' AS [Information], vs.logical_volume_name,\r\n\t\tvs.volume_mount_point, vs.file_system_type, CONVERT(int,vs.total_bytes/1048576.0) AS TotalSpace_MB,\r\n\t\tCONVERT(int,vs.available_bytes/1048576.0) AS FreeSpace_MB, vs.is_compressed\r\n\tFROM sys.master_files mf\r\n\tCROSS APPLY sys.dm_os_volume_stats(mf.database_id, mf.[file_id]) vs\r\n\tORDER BY FreeSpace_MB ASC\r\nEND;"
+  ],
+  "metadata": {
+    "azdata_cell_guid": "4959e824-8ec9-4d6a-9107-a377bd4ab58d"
+  },
+  "outputs": [
+    {
+      "output_type": "stream",
+      "text": "",
+      "name": "stdout"
+    }
+  ]
+}
+    ]
+}


### PR DESCRIPTION
Removed all `-Skip`s from GetParsedSqlOffsets.tests.ps1 file.  All tests passed locally using Pester v5.