### PR TITLE
Added handling for files with single code blocks.

### DIFF
--- a/ConvertToPowerShellNoteBook.ps1
+++ b/ConvertToPowerShellNoteBook.ps1
@@ -41,12 +41,23 @@ function ConvertTo-PowerShellNoteBook {
     $Previous = $null
     $AllBlocks = $CommentRanges
     <# Catch anything missed from the tail of the file, add it to $AllBlocks #>
-    if(($CommentBlock.Start+$CommentBlock.Length) -lt $s.Length){$AllBlocks+=[pscustomobject][ordered]@{
-        Start = ($CommentBlock.Start+$CommentBlock.Length);
-        Length = $s.Length-($CommentBlock.Start+$CommentBlock.Length);
-        Type = 'Gap';
-        Content = $s.Substring(($CommentBlock.Start+$CommentBlock.Length), ($s.Length-($CommentBlock.Start+$CommentBlock.Length))).trimstart()}
-    }
+        if($BlocksWitGaps.Count -eq 1){
+            <# This step handles ading the psobjects together if $CommentBlock isn't an array. #>
+            $AllBlocks = @($CommentBlock;[pscustomobject][Ordered]@{
+            Start = ($CommentBlock.Start+$CommentBlock.Length);
+            Length = $s.Length-($CommentBlock.Start+$CommentBlock.Length);
+            Type = 'Gap';
+            Content = $s.Substring(($CommentBlock.Start+$CommentBlock.Length), ($s.Length-($CommentBlock.Start+$CommentBlock.Length))).trimstart()})
+        }
+        else {
+            if(($CommentBlock.Start+$CommentBlock.Length) -lt $s.Length){
+                $AllBlocks+=[pscustomobject][ordered]@{
+                Start = ($CommentBlock.Start+$CommentBlock.Length);
+                Length = $s.Length-($CommentBlock.Start+$CommentBlock.Length);
+                Type = 'Gap';
+                Content = $s.Substring(($CommentBlock.Start+$CommentBlock.Length), ($s.Length-($CommentBlock.Start+$CommentBlock.Length))).trimstart()}
+            }
+        }
     
     foreach($GapBlock in $BlocksWitGaps ) {
         $GapOffsets=[ordered]@{

--- a/__tests__/ConvertToPowerShellNotebook.tests.ps1
+++ b/__tests__/ConvertToPowerShellNotebook.tests.ps1
@@ -27,7 +27,7 @@ Describe "Test ConvertTo-PowerShellNoteBook" {
         $actual[2].Source | Should -BeExactly '# Create a function'
         $actual[3].Source | Should -BeExactly '# Use the function'
     }
-    It "Should convert the file to an ipynb" {
+    It "Should convert the file with a single comment and single line of code to an ipynb" {
         $demoTextFile = "$PSScriptRoot\DemoFiles\demo_SingleCommentSingleLineCodeBlock.ps1"
         $fullName = "TestDrive:\testConverted.ipynb"
 
@@ -39,12 +39,12 @@ Describe "Test ConvertTo-PowerShellNoteBook" {
 
         $actual = Get-NotebookContent -NoteBookFullName $fullName -JustCode
 
-        $actual.Count | Should -Be 1
+        @($actual).Count | Should -Be 1
         $actual[0].Source | Should -BeExactly 'ps | select -first 10'
 
         $actual = Get-NotebookContent -NoteBookFullName $fullName -JustMarkdown
 
-        $actual.Count | Should -Be 1
+        @($actual).Count | Should -Be 1
         $actual[0].Source | Should -BeExactly '# Get first 10 process'
     }
 

--- a/__tests__/ConvertToPowerShellNotebook.tests.ps1
+++ b/__tests__/ConvertToPowerShellNotebook.tests.ps1
@@ -27,6 +27,26 @@ Describe "Test ConvertTo-PowerShellNoteBook" {
         $actual[2].Source | Should -BeExactly '# Create a function'
         $actual[3].Source | Should -BeExactly '# Use the function'
     }
+    It "Should convert the file to an ipynb" {
+        $demoTextFile = "$PSScriptRoot\DemoFiles\demo_SingleCommentSingleLineCodeBlock.ps1"
+        $fullName = "TestDrive:\testConverted.ipynb"
+
+        ConvertTo-PowerShellNoteBook -InputFileName $demoTextFile -OutputNotebookName $fullName
+        { Test-Pat $fullName } | Should -Be $true
+
+        $actual = Get-NotebookContent -NoteBookFullName $fullName
+        $actual.Count | Should -Be 2
+
+        $actual = Get-NotebookContent -NoteBookFullName $fullName -JustCode
+
+        $actual.Count | Should -Be 1
+        $actual[0].Source | Should -BeExactly 'ps | select -first 10'
+
+        $actual = Get-NotebookContent -NoteBookFullName $fullName -JustMarkdown
+
+        $actual.Count | Should -Be 1
+        $actual[0].Source | Should -BeExactly '# Get first 10 process'
+    }
 
     It "Should convert the file to an ipynb" {
         $demoTextFile = "$PSScriptRoot\DemoFiles\GetParsedSqlOffsets.ps1"

--- a/__tests__/DemoFiles/demo_SingleCommentSingleLineCodeBlock.ps1
+++ b/__tests__/DemoFiles/demo_SingleCommentSingleLineCodeBlock.ps1
@@ -1,0 +1,2 @@
+﻿# Get first 10 process
+ps | select -first 10


### PR DESCRIPTION
This command has been previously tested against larger files with multiple code & comment blocks.  However, a simple file with a single comment & code block would throw an error because it was not an array.  This update adds handling for files with single code blocks.