### PR TITLE
Remove #!pwsh shebang from powershell code block

### DIFF
--- a/ConvertFromNotebookToMarkdown.ps1
+++ b/ConvertFromNotebookToMarkdown.ps1
@@ -12,7 +12,7 @@ function ConvertFrom-NotebookToMarkdown {
     $text = $(switch (Get-NotebookContent -NoteBookFullName $NotebookName) {
             { $_.Type -eq 'markdown' } { $_.Source }
             { $_.Type -eq 'code' } {
-                '```powershell' + "`n" + $_.Source.Replace("#!pwsh`n", "") + "`n" + '```' + "`n"
+                '```powershell' + "`n" + ($_.Source | Where-Object { -not "#!pwsh\n" }) + "`n" + '```' + "`n"
             }
         })
 

--- a/ConvertFromNotebookToMarkdown.ps1
+++ b/ConvertFromNotebookToMarkdown.ps1
@@ -12,7 +12,7 @@ function ConvertFrom-NotebookToMarkdown {
     $text = $(switch (Get-NotebookContent -NoteBookFullName $NotebookName) {
             { $_.Type -eq 'markdown' } { $_.Source }
             { $_.Type -eq 'code' } {
-                '```powershell' + "`n" + $_.Source + "`n" + '```' + "`n"
+                '```powershell' + "`n" + $_.Source.Replace("#!pwsh`n", "") + "`n" + '```' + "`n"
             }
         })
 

--- a/__tests__/ConvertFromNotebookToMarkdown.tests.ps1
+++ b/__tests__/ConvertFromNotebookToMarkdown.tests.ps1
@@ -34,7 +34,7 @@ Describe "Test ConvertFrom-NoteBookToMarkdown" {
 
         $powerShellCodeBlock = $actual[1]
         
-        $powerShellCodeBlock.Split([System.Environment]::NewLine) | Should -Not -Contain "#!pwsh"
+        $powerShellCodeBlock.Split("`n") | Should -Not -Contain "#!pwsh"
     }
     
     It "Should not remove the #!pwsh shebang in markdown blocks" {
@@ -44,6 +44,6 @@ Describe "Test ConvertFrom-NoteBookToMarkdown" {
 
         $markDownBlock = $actual[2]
         
-        $markDownBlock.Split([System.Environment]::NewLine) | Should -Contain "#!pwsh"
+        $markDownBlock.Split("`n") | Should -Contain "#!pwsh"
     }
 }

--- a/__tests__/ConvertFromNotebookToMarkdown.tests.ps1
+++ b/__tests__/ConvertFromNotebookToMarkdown.tests.ps1
@@ -26,4 +26,24 @@ Describe "Test ConvertFrom-NoteBookToMarkdown" {
 
         Remove-Item $expected -ErrorAction SilentlyContinue
     }
+    
+    It "Should remove the #!pwsh shebang in code blocks" {
+        $targetFile = "$PSScriptRoot\DotNetInteractiveNotebooks\PwshShebangTest.ipynb"
+
+        $actual = ConvertFrom-NotebookToMarkdown -NotebookName $targetFile -AsText
+
+        $powerShellCodeBlock = $actual[1]
+        
+        $powerShellCodeBlock.Split([System.Environment]::NewLine) | Should -Not -Contain "#!pwsh"
+    }
+    
+    It "Should not remove the #!pwsh shebang in markdown blocks" {
+        $targetFile = "$PSScriptRoot\DotNetInteractiveNotebooks\PwshShebangTest.ipynb"
+
+        $actual = ConvertFrom-NotebookToMarkdown -NotebookName $targetFile -AsText
+
+        $markDownBlock = $actual[2]
+        
+        $markDownBlock.Split([System.Environment]::NewLine) | Should -Contain "#!pwsh"
+    }
 }

--- a/__tests__/DotNetInteractiveNotebooks/PwshShebangTest.ipynb
+++ b/__tests__/DotNetInteractiveNotebooks/PwshShebangTest.ipynb
@@ -1,0 +1,259 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This is a test Notebook written in .NET Interactive. \n",
+    "The code blocks in this Notebook will be set to PowerShell. \n",
+    "In the underlying data, we will see a `#!pwsh` shebang added to the top of each code block.\n",
+    "When converting to MarkDown, we don't need that shebang anymore."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "source": [
+    "#!pwsh\n",
+    "# Some code\n",
+    "Get-Host \n",
+    "$PSVersionTable | Out-Default"
+   ],
+   "outputs": [
+    {
+     "output_type": "execute_result",
+     "data": {
+      "text/plain": "\r\n"
+     },
+     "execution_count": 1,
+     "metadata": {}
+    },
+    {
+     "output_type": "execute_result",
+     "data": {
+      "text/plain": "Name             : .NET Interactive Host\r\n"
+     },
+     "execution_count": 1,
+     "metadata": {}
+    },
+    {
+     "output_type": "execute_result",
+     "data": {
+      "text/plain": "Version          : 0.0.1\r\n"
+     },
+     "execution_count": 1,
+     "metadata": {}
+    },
+    {
+     "output_type": "execute_result",
+     "data": {
+      "text/plain": "InstanceId       : ee9ac7f0-dd60-467e-a210-4cfee88166ff\r\n"
+     },
+     "execution_count": 1,
+     "metadata": {}
+    },
+    {
+     "output_type": "execute_result",
+     "data": {
+      "text/plain": "UI               : System.Management.Automation.Internal.Host.InternalHostUserInterface\r\n"
+     },
+     "execution_count": 1,
+     "metadata": {}
+    },
+    {
+     "output_type": "execute_result",
+     "data": {
+      "text/plain": "CurrentCulture   : nl-NL\r\n"
+     },
+     "execution_count": 1,
+     "metadata": {}
+    },
+    {
+     "output_type": "execute_result",
+     "data": {
+      "text/plain": "CurrentUICulture : en-US\r\n"
+     },
+     "execution_count": 1,
+     "metadata": {}
+    },
+    {
+     "output_type": "execute_result",
+     "data": {
+      "text/plain": "PrivateData      : Microsoft.DotNet.Interactive.PowerShell.Host.ConsoleColorProxy\r\n"
+     },
+     "execution_count": 1,
+     "metadata": {}
+    },
+    {
+     "output_type": "execute_result",
+     "data": {
+      "text/plain": "DebuggerEnabled  : True\r\n"
+     },
+     "execution_count": 1,
+     "metadata": {}
+    },
+    {
+     "output_type": "execute_result",
+     "data": {
+      "text/plain": "IsRunspacePushed : False\r\n"
+     },
+     "execution_count": 1,
+     "metadata": {}
+    },
+    {
+     "output_type": "execute_result",
+     "data": {
+      "text/plain": "Runspace         : \r\n"
+     },
+     "execution_count": 1,
+     "metadata": {}
+    },
+    {
+     "output_type": "execute_result",
+     "data": {
+      "text/plain": "\r\n"
+     },
+     "execution_count": 1,
+     "metadata": {}
+    },
+    {
+     "output_type": "execute_result",
+     "data": {
+      "text/plain": "\r\n"
+     },
+     "execution_count": 1,
+     "metadata": {}
+    },
+    {
+     "output_type": "execute_result",
+     "data": {
+      "text/plain": "Name                           Value\r\n"
+     },
+     "execution_count": 1,
+     "metadata": {}
+    },
+    {
+     "output_type": "execute_result",
+     "data": {
+      "text/plain": "----                           -----\r\n"
+     },
+     "execution_count": 1,
+     "metadata": {}
+    },
+    {
+     "output_type": "execute_result",
+     "data": {
+      "text/plain": "PSVersion                      7.0.3\r\n"
+     },
+     "execution_count": 1,
+     "metadata": {}
+    },
+    {
+     "output_type": "execute_result",
+     "data": {
+      "text/plain": "PSEdition                      Core\r\n"
+     },
+     "execution_count": 1,
+     "metadata": {}
+    },
+    {
+     "output_type": "execute_result",
+     "data": {
+      "text/plain": "GitCommitId                    7.0.3\r\n"
+     },
+     "execution_count": 1,
+     "metadata": {}
+    },
+    {
+     "output_type": "execute_result",
+     "data": {
+      "text/plain": "OS                             Microsoft Windows 10.0.19042\r\n"
+     },
+     "execution_count": 1,
+     "metadata": {}
+    },
+    {
+     "output_type": "execute_result",
+     "data": {
+      "text/plain": "Platform                       Win32NT\r\n"
+     },
+     "execution_count": 1,
+     "metadata": {}
+    },
+    {
+     "output_type": "execute_result",
+     "data": {
+      "text/plain": "PSCompatibleVersions           {1.0, 2.0, 3.0, 4.0…}\r\n"
+     },
+     "execution_count": 1,
+     "metadata": {}
+    },
+    {
+     "output_type": "execute_result",
+     "data": {
+      "text/plain": "PSRemotingProtocolVersion      2.3\r\n"
+     },
+     "execution_count": 1,
+     "metadata": {}
+    },
+    {
+     "output_type": "execute_result",
+     "data": {
+      "text/plain": "SerializationVersion           1.1.0.1\r\n"
+     },
+     "execution_count": 1,
+     "metadata": {}
+    },
+    {
+     "output_type": "execute_result",
+     "data": {
+      "text/plain": "WSManStackVersion              3.0\r\n"
+     },
+     "execution_count": 1,
+     "metadata": {}
+    },
+    {
+     "output_type": "execute_result",
+     "data": {
+      "text/plain": "\r\n"
+     },
+     "execution_count": 1,
+     "metadata": {}
+    },
+    {
+     "output_type": "execute_result",
+     "data": {
+      "text/plain": "\r\n"
+     },
+     "execution_count": 1,
+     "metadata": {}
+    }
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#!pwsh\n",
+    "this ^ shebang should be left alone."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": ".NET (C#)",
+   "language": "C#",
+   "name": ".net-csharp"
+  },
+  "language_info": {
+   "file_extension": ".cs",
+   "mimetype": "text/x-csharp",
+   "name": "C#",
+   "pygments_lexer": "csharp",
+   "version": "8.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}


### PR DESCRIPTION
.NET Interactive Notebooks add this shebang, it needs to be removed to get a nice, clean export.